### PR TITLE
Export default http encoder

### DIFF
--- a/orion/handlers/http.go
+++ b/orion/handlers/http.go
@@ -222,7 +222,10 @@ func GrpcErrorToHTTP(err error, defaultStatus int, defaultMessage string) (int, 
 	return code, msg
 }
 
-func defaultEncoder(r interface{}, req *http.Request) error {
+// DefaultEncoder encodes a HTTP request if none are registered. This encoder
+// populates the proto message with URL route variables or fields from a JSON
+// body if either are available.
+func DefaultEncoder(req *http.Request, r interface{}) error {
 	protoReq := r.(proto.Message)
 	// check and map url params to request
 	params := mux.Vars(req)
@@ -256,7 +259,7 @@ func (h *httpHandler) serveHTTP(resp http.ResponseWriter, req *http.Request, url
 			if info.encoder != nil {
 				encErr = info.encoder(req, r)
 			} else {
-				encErr = defaultEncoder(r, req)
+				encErr = DefaultEncoder(req, r)
 			}
 			return encErr
 		}


### PR DESCRIPTION
Exporting the default encoder will allow chaining multiple encoders while still using the upstream default encoder implementation.

Eg.
https://github.com/carousell/djgateway/blob/b40affd0a0d2b2810ee8ce3c8121cf6ad65dc195/djgateway/service/init.go#L93-L109
```go
import "github.com/carousell/Orion/handlers"

// defaultRequestEncoder will attempt to extract http params and multipart
// files from the request into specific proto fields, if the proto fields are
// defined.
func defaultRequestEncoder(req *http.Request, reqObject interface{}) error {
	var err error
	err = httpMultipartFilesEncoder(req, reqObject)
	if err != nil {
		return err
	}
	err = httpParamsEncoder(req, reqObject)
	if err != nil {
		return err
	}
	return handlers.DefaultEncoder(req, reqObject)
}
```