### PR TITLE
Set `shouldNotify` to true when new an error

### DIFF
--- a/utils/errors/errors.go
+++ b/utils/errors/errors.go
@@ -156,8 +156,9 @@ func WrapWithSkip(err error, msg string, skip int) ErrorExt {
 	}
 
 	c := &customError{
-		Msg:   msg + err.Error(),
-		cause: err,
+		Msg:          msg + err.Error(),
+		cause:        err,
+		shouldNotify: true,
 	}
 	c.generateStack(skip + 1)
 	return c


### PR DESCRIPTION
`shouldNotify` should be true when the error is first time initiated or
`Notifier.Notify` will skip any error from `WrapWithSkip`