### PR TITLE
Add an option to set a queue name for a task

### DIFF
--- a/utils/worker/types.go
+++ b/utils/worker/types.go
@@ -36,7 +36,8 @@ type wrappedWork func(payload string) error
 
 //ScheduleConfig is the config used when scheduling a task
 type ScheduleConfig struct {
-	retries int
+	retries   int
+	queueName string
 }
 
 //ScheduleOption represents different options available for Schedule

--- a/utils/worker/worker.go
+++ b/utils/worker/worker.go
@@ -34,6 +34,13 @@ func WithRetry(n int) ScheduleOption {
 	}
 }
 
+//WithQueueName sets the destination queue for this task
+func WithQueueName(queueName string) ScheduleOption {
+	return func(c *ScheduleConfig) {
+		c.queueName = queueName
+	}
+}
+
 func (w *worker) Schedule(ctx context.Context, name string, payload string, options ...ScheduleOption) error {
 	span, ctx := spanutils.NewInternalSpan(ctx, name+"Scheduled")
 	defer span.End()
@@ -61,6 +68,7 @@ func (w *worker) scheduleRemote(ctx context.Context, name string, payload string
 		},
 	}
 	signature.RetryCount = c.retries
+	signature.RoutingKey = c.queueName
 	_, err := w.server.SendTask(signature)
 	if err != nil {
 		return err


### PR DESCRIPTION
Allow specifying custom queue name for a task. If not set, it will pick from default worker queue name.

```go
import (
    orion_worker "github.com/carousell/Orion/utils/worker"
    ...
)

...
taskName := "transform_image"
queueName := "transform_image_jpg"
payload := "https://media.karousell.com/sample.jpg"
m.worker.Schedule(ctx, taskName, payload, orion_worker.WithQueueName(queueName))
```