### PR TITLE
Moving pubsub subscriber to a simple parser function based instead of…

### DIFF
--- a/utils/pubsub/message_queue/mocks/MessageQueue.go
+++ b/utils/pubsub/message_queue/mocks/MessageQueue.go
@@ -76,27 +76,16 @@ func (_m *MessageQueue) Publish(_a0 string, _a1 *message_queue.PubSubData) *pubs
 	return r0
 }
 
-// SubscribeMessages provides a mock function with given fields: ctx, subscriptionId, autoAck
-func (_m *MessageQueue) SubscribeMessages(ctx context.Context, subscriptionId string, autoAck bool) (chan pubsub.Message, chan error) {
-	ret := _m.Called(ctx, subscriptionId, autoAck)
+// SubscribeMessages provides a mock function with given fields: ctx, subscriptionId, subscribeFunction
+func (_m *MessageQueue) SubscribeMessages(ctx context.Context, subscriptionId string, subscribeFunction message_queue.SubscribeFunction) error {
+	ret := _m.Called(ctx, subscriptionId, subscribeFunction)
 
-	var r0 chan pubsub.Message
-	if rf, ok := ret.Get(0).(func(context.Context, string, bool) chan pubsub.Message); ok {
-		r0 = rf(ctx, subscriptionId, autoAck)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, message_queue.SubscribeFunction) error); ok {
+		r0 = rf(ctx, subscriptionId, subscribeFunction)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(chan pubsub.Message)
-		}
+		r0 = ret.Error(0)
 	}
 
-	var r1 chan error
-	if rf, ok := ret.Get(1).(func(context.Context, string, bool) chan error); ok {
-		r1 = rf(ctx, subscriptionId, autoAck)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(chan error)
-		}
-	}
-
-	return r0, r1
+	return r0
 }


### PR DESCRIPTION
… channel

Also google's pubsub client already has internal implementations for running multiple go routines based on load and CPU.