### PR TITLE
Handle empty payload for HTTP Get method

### DIFF
--- a/orion/handlers/http/defaults.go
+++ b/orion/handlers/http/defaults.go
@@ -34,6 +34,9 @@ func DefaultEncoder(req *http.Request, r interface{}) error {
 		return err
 	}
 
+	if req.Method == http.MethodGet && len(data) == 0 {
+		return nil
+	}
 	return deserialize(req.Context(), data, r)
 }
 


### PR DESCRIPTION
Most of the time, HTTP GET requests don't have any payload.
With this PR, empty payload on HTTP GET requests will be ignored.