### PR TITLE
Restrict protoc-gen-orion to input files

### DIFF
--- a/protoc-gen-orion/orion.go
+++ b/protoc-gen-orion/orion.go
@@ -194,15 +194,21 @@ func main() {
 	if len(request.FileToGenerate) == 0 {
 		logFail("no files to generate")
 	}
+	filesToGenerate := make(map[string]bool)
+	for _, v := range request.FileToGenerate {
+		filesToGenerate[v] = true
+	}
 
 	response := new(plugin.CodeGeneratorResponse)
 	response.File = make([]*plugin.CodeGeneratorResponse_File, 0)
 
 	for _, file := range request.GetProtoFile() {
-		// check if file has any service
-		if len(file.Service) > 0 {
-			f := generateFile(populate(file))
-			response.File = append(response.File, f)
+		if _, ok := filesToGenerate[file.GetName()]; ok {
+			// check if file has any service
+			if len(file.Service) > 0 {
+				f := generateFile(populate(file))
+				response.File = append(response.File, f)
+			}
 		}
 	}
 


### PR DESCRIPTION
Previously protoc-gen-orion was generating files for imported services as well. Protoc-gen-go should only generate files for those explicitly specified as input files. This is the expected behavior as defined by the docs:

https://github.com/carousell/Orion/blob/723ade08e02a7d3347c8eed46c7bb9525ac2ec70/vendor/github.com/golang/protobuf/protoc-gen-go/plugin/plugin.pb.go#L98-L101

Demos below

## Before

https://github.com/carousell/Orion/compare/restrict-protoc-gen-orion-to-input-files-BEFORE

In this example we are working on the `foo` service, which imports a message from `bar` service. We only want to generate protobufs and orion.pb.go files for our service, so we run:

```
protoc -I ./ --go_out=plugins=grpc:. --orion_out=. foo/foo.proto
```

Note that we only generate protos for `foo/foo.proto`, but the following are generated:
- `demo/foo/foo.proto.orion.pb.go`
- `demo/bar/bar.proto.orion.pb.go`

`demo/bar/bar.proto.orion.pb.go` should not be generated because it's not relevant to our service.

## After

https://github.com/carousell/Orion/compare/restrict-protoc-gen-orion-to-input-files-AFTER

Only `demo/foo/foo.proto.orion.pb.go` is generated as expected.

## Real world examples

More practical examples of how we're currently working around this in Carousell: https://github.com/search?q=org%3Acarousell+messaging.proto.orion.pb.go&type=Code