### PR TITLE
Option to make JSONPB the default JSON encoder/decoder

### DIFF
--- a/orion/config.go
+++ b/orion/config.go
@@ -143,7 +143,7 @@ func setConfigDefaults() {
 	viper.SetDefault("orion.EnablePrometheus", true)
 	viper.SetDefault("orion.EnablePrometheusHistogram", false)
 	viper.SetDefault("orion.Env", "development")
-	viper.SetDefault("orion.DefaultJSONPB", true)
+	viper.SetDefault("orion.DefaultJSONPB", false)
 }
 
 // sets up the config parser

--- a/orion/config.go
+++ b/orion/config.go
@@ -49,6 +49,8 @@ type Config struct {
 	SentryDSN string
 	//Env is the environment this service is running in
 	Env string
+	// DefaultJSONPB sets jsonpb as the encoder/decoder for application/json request/response bodies
+	DefaultJSONPB bool
 }
 
 // HystrixConfig is configuration used by hystrix
@@ -96,6 +98,7 @@ func BuildDefaultConfig(name string) Config {
 		HystrixConfig:             BuildDefaultHystrixConfig(),
 		ZipkinConfig:              BuildDefaultZipkinConfig(),
 		NewRelicConfig:            BuildDefaultNewRelicConfig(),
+		DefaultJSONPB:             viper.GetBool("orion.DefaultJSONPB"),
 	}
 }
 
@@ -140,6 +143,7 @@ func setConfigDefaults() {
 	viper.SetDefault("orion.EnablePrometheus", true)
 	viper.SetDefault("orion.EnablePrometheusHistogram", false)
 	viper.SetDefault("orion.Env", "development")
+	viper.SetDefault("orion.DefaultJSONPB", true)
 }
 
 // sets up the config parser

--- a/orion/core.go
+++ b/orion/core.go
@@ -239,6 +239,7 @@ func (d *DefaultServerImpl) buildHandlers() []*handlerInfo {
 		log.Info(context.Background(), "HTTPListnerPort", httpPort)
 		config := http.Config{
 			EnableProtoURL: d.config.EnableProtoURL,
+			DefaultJSONPB:  d.config.DefaultJSONPB,
 		}
 		handler := http.NewHTTPHandler(config)
 		hlrs = append(hlrs, &handlerInfo{

--- a/orion/handlers/http/defaults.go
+++ b/orion/handlers/http/defaults.go
@@ -18,8 +18,9 @@ import (
 
 // DefaultEncoder encodes a HTTP request if none are registered. This encoder
 // populates the proto message with URL route variables or fields from a JSON
-// body if either are available.
-func DefaultEncoder(req *http.Request, r interface{}) error {
+// body if either are available. If JSONPB is true, JSON requests are encoded
+// using the jsonpb package.
+func DefaultEncoder(req *http.Request, r interface{}, JSONPB bool) error {
 	// check and map url params to request
 	params := mux.Vars(req)
 	if len(params) > 0 {
@@ -37,25 +38,22 @@ func DefaultEncoder(req *http.Request, r interface{}) error {
 	if req.Method == http.MethodGet && len(data) == 0 {
 		return nil
 	}
-	return deserialize(req.Context(), data, r)
+	return deserialize(req.Context(), data, r, JSONPB)
 }
 
-func deserialize(ctx context.Context, data []byte, r interface{}) error {
+func deserialize(ctx context.Context, data []byte, r interface{}, JSONPB bool) error {
 	serType := ContentTypeFromHeaders(ctx)
-	switch serType {
-	case modifiers.ProtoBuf:
+	if serType == modifiers.ProtoBuf {
 		if protoReq, ok := r.(proto.Message); ok {
 			return proto.Unmarshal(data, protoReq)
 		}
-		fallthrough
-	case modifiers.JSONPB:
+	}
+	if serType == modifiers.JSONPB || JSONPB {
 		if protoReq, ok := r.(proto.Message); ok {
 			return jsonpb.UnmarshalString(string(data), protoReq)
 		}
-		fallthrough
-	default:
-		return json.Unmarshal(data, r)
 	}
+	return json.Unmarshal(data, r)
 }
 
 // DefaultWSUpgrader upgrades a websocket if none are registered.

--- a/orion/handlers/http/http.go
+++ b/orion/handlers/http/http.go
@@ -203,16 +203,25 @@ func (h *httpHandler) serialize(ctx context.Context, msg proto.Message) ([]byte,
 				serType = modifiers.JSON
 			}
 		}
+		// if server preference is JSONPB, JSONPB should be used instead of JSON for marshalling
+		if serType == modifiers.JSON && h.config.DefaultJSONPB {
+			serType = modifiers.JSONPB
+		}
 	}
-	if serType == modifiers.ProtoBuf {
-		data, err := proto.Marshal(msg)
-		return data, ContentTypeProto, err
-	} else if serType == modifiers.JSONPB || h.config.DefaultJSONPB {
+	switch serType {
+	case modifiers.JSONPB:
 		sData, err := h.mar.MarshalToString(msg)
 		return []byte(sData), ContentTypeJSON, err
+	case modifiers.ProtoBuf:
+		data, err := proto.Marshal(msg)
+		return data, ContentTypeProto, err
+	case modifiers.JSON:
+		fallthrough
+	default:
+		// modifiers.JSON goes in here
+		data, err := json.Marshal(msg)
+		return data, ContentTypeJSON, err
 	}
-	data, err := json.Marshal(msg)
-	return data, ContentTypeJSON, err
 }
 
 func (h *httpHandler) serializeOut(ctx context.Context, resp http.ResponseWriter, msg proto.Message, responseHeaders http.Header) error {

--- a/orion/handlers/http/types.go
+++ b/orion/handlers/http/types.go
@@ -43,6 +43,7 @@ const (
 type Config struct {
 	handlers.CommonConfig
 	EnableProtoURL bool
+	DefaultJSONPB  bool
 }
 
 type serviceInfo struct {

--- a/orion/handlers/http/ws.go
+++ b/orion/handlers/http/ws.go
@@ -127,7 +127,7 @@ func (s *streamServer) RecvMsg(m interface{}) error {
 	case websocket.TextMessage:
 		fallthrough
 	case websocket.BinaryMessage:
-		return deserialize(s.Context(), data, m)
+		return deserialize(s.Context(), data, m, false)
 	case websocket.CloseMessage:
 		return io.EOF
 	}


### PR DESCRIPTION
For several services that use JSON, we would like to use the `jsonpb` package instead of the `json` package for request and response encoding. Clients should be able to pass `application/json` as the `Content-Type`/`Accept` header, and should not be required to pass `application/jsonpb`.

Currently you can force an endpoint to serialize out JSONPB with the `modifiers.SerializeOutJSONPB` modifier, but this is not an ideal solution because it prevents clients from specifying a different response format in the `Accept` header, such as protobuf.

In this PR I have added a new option for Orion servers: `DefaultJSONPB`. If set to `true`, any requests or responses which have specified `application/json` will use the `jsonpb` marshaller instead of the `json` marshaller. The default value for this setting is `false`, for backwards compatibility.