### PR TITLE
add PanicRecoverInterceptor for both http and grpc

### DIFF
--- a/interceptors/interceptors.go
+++ b/interceptors/interceptors.go
@@ -3,7 +3,6 @@ package interceptors
 import (
 	"context"
 	"fmt"
-	"runtime/debug"
 	"strings"
 	"time"
 
@@ -145,7 +144,6 @@ func PanicRecoveryInterceptor() grpc.UnaryServerInterceptor {
 			// panic handler
 			if r := recover(); r != nil {
 				log.Error(ctx, "panic", r, "method", info.FullMethod)
-				log.Error(ctx, string(debug.Stack()))
 				if e, ok := r.(error); ok {
 					err = e
 				} else {


### PR DESCRIPTION
this PR is to enable GRPC call handling panic gracefully rather than crashing server that the server can still serve other endpoints normally.

GRPC logs before fix:
```
{"@timestamp":"2019-08-26T14:58:25.81985+08:00","caller":"interceptors/interceptors.go:91","error":null,"grpcMethod":"/listing_proto.ListingService/GetListings","level":"info","method":"/listing_proto.ListingService/GetListings","took":"181.931µs","trace":"e6a3d3c0-c7ce-11e9-a1c7-8c8590b37a1d","transport":"gRPC"}
panic: yoyyo

goroutine 169 [running]:
github.com/carousell/listing/listing/service.(*svc).GetListings(0xc0005ba340, 0x4ee4e20, 0xc00149f830, 0xc00048be50, 0x0, 0x0, 0x0)
	/Users/hothero/go/src/github.com/carousell/listing/listing/service/internal.go:536 +0xa5
github.com/carousell/listing/listing/listing_proto._ListingService_GetListings_Handler.func1(0x4ee4e20, 0xc00149f830, 0x4bd1dc0, 0xc00048be50, 0x0, 0xc0011ce820, 0x4ee4e20, 0x29)
	/Users/hothero/go/src/github.com/carousell/listing/listing/listing_proto/listing.pb.go:7675 +0x86
... (skipped)
created by github.com/carousell/listing/vendor/google.golang.org/grpc.(*Server).serveStreams.func1
	/Users/hothero/go/src/github.com/carousell/listing/vendor/google.golang.org/grpc/server.go:688 +0xa1
exit status 2
➜  listing git:(orion-grpc-panic-recover) ✗
```
HTTP logs before fix:
```
{"@timestamp":"2019-08-26T15:00:20.176002+08:00","caller":"http/http.go:40","grpcMethod":"/listing_proto.ListingService/GetListings","level":"error","method":"POST","panic":"yoyyo","path":"/listingservice/getlistings/","took":"425.426µs","trace":"2acd3280-c7cf-11e9-b773-8c8590b37a1d","transport":"http"}
{"@timestamp":"2019-08-26T15:00:20.176526+08:00","caller":"http/http.go:41","grpcMethod":"/listing_proto.ListingService/GetListings","level":"error","msg":"goroutine 193 [running]:\nruntime/debug.Stack(0x4ee4e20, 0xc00154c750, 0xc00154f400)\n\t/usr/local/Cellar/go/1.12.9/libexec/src/runtime/debug/stack.go:24 +0x9d\ngithub.com/carousell/listing/vendor/github.com/carousell/Orion/orion/handlers/http.(*httpHandler).httpHandler.func1(0xc001ec7b60, 0xc001ec7b08, 0x4ee1260, 0xc000d5e2a0, 0x4ee4e20, 0xc00154c750, 0xbf50fec10a76e0f8, 0xf12b8299f, 0x747ab
... (skipped)
{"@timestamp":"2019-08-26T15:08:12.187945+08:00","caller":"http/http.go:36","error":"panic: yoyyo: panic: yoyyo","grpcMethod":"/listing_proto.ListingService/GetListings","level":"info","method":"POST","path":"/listingservice/getlistings/","took":"11.346504ms","trace":"4422c78a-c7d0-11e9-b44b-8c8590b37a1d","transport":"http"}
```

------ line-separator -------
GRPC logs after fix
```
{"@timestamp":"2019-08-26T15:05:34.542089+08:00","caller":"interceptors/interceptors.go:147","grpcMethod":"/listing_proto.ListingService/GetListings","level":"error","method":"/listing_proto.ListingService/GetListings","panic":"yoyyo","trace":"e62da64a-c7cf-11e9-b44b-8c8590b37a1d","transport":"gRPC"}
{"@timestamp":"2019-08-26T15:05:34.544755+08:00","caller":"interceptors/interceptors.go:148","grpcMethod":"/listing_proto.ListingService/GetListings","level":"error","msg":"goroutine 120 [running]:\nruntime/debug.Stack(0x4ee4540, 0xc0003e4d50, 0xc0003131c0)\n\t/usr/local/Cellar/go/1.12.9/libexec/src/runtime/debug/stack.go:24 +0x9d\ngithub.com/carousell/Orion/interceptors.PanicRecoveryInterceptor.func1.1(0xc0003c6a00, 0xc0004d54a0, 0x4ee4540, 0xc0003e4d50)\n\t/Users/hothero/go/pkg/mod/github.com/carousell/!orion@v0.0.0-20190701105319-d2b60466087f/interceptors/interceptors.go:148 +0x157\npanic(0x4a3f120, 0x4eaf570)\n\t/usr/local/Cellar/go/1.12.9/libexec/src/runtime/panic.go:522 +0x1b5\ngithub.com/carousell/listing/listing/service.(*svc).GetListings(0xc00093a750, 0x4ee4540, 0xc0003e4d50, 0xc00234
... (skipped)
{"@timestamp":"2019-08-26T15:07:27.164003+08:00","caller":"interceptors/interceptors.go:91","error":"panic: yoyyo","grpcMethod":"/listing_proto.ListingService/GetListings","level":"info","method":"/listing_proto.ListingService/GetListings","took":"6.529734ms","trace":"294d6992-c7d0-11e9-b44b-8c8590b37a1d","transport":"gRPC"}
```
^ you can see the server keep runing without exit signal

HTTP logs after fix
```
{"@timestamp":"2019-08-26T15:08:12.176613+08:00","caller":"interceptors/interceptors.go:147","grpcMethod":"/listing_proto.ListingService/GetListings","level":"error","method":"/listing_proto.ListingService/GetListings","panic":"yoyyo","trace":"4422c78a-c7d0-11e9-b44b-8c8590b37a1d","transport":"http"}
{"@timestamp":"2019-08-26T15:08:12.176934+08:00","caller":"interceptors/interceptors.go:148","grpcMethod":"/listing_proto.ListingService/GetListings","level":"error","msg":"goroutine 390 [running]:\nruntime/debug.Stack(0x4ee4540, 0xc0014cb080, 0xc001602140)\n\t/usr/local/Cellar/go/1.12.9/libexec/src/runtime/debug/stack.go:24 +0x9d\ngithub.com/carousell/Orion/interceptors.PanicRecoveryInterceptor.func1.1(0xc0003f4020, 0xc0013b3240, 0x4ee4540, 0xc0014cb080)\n\t/Users/hothero/go/pkg/mod/github.com/carousell/!orion@v0.0.0-20190701105319-d2b6046608
... (skipped)
{"@timestamp":"2019-08-26T15:08:12.187945+08:00","caller":"http/http.go:36","error":"panic: yoyyo: panic: yoyyo","grpcMethod":"/listing_proto.ListingService/GetListings","level":"info","method":"POST","path":"/listingservice/getlistings/","took":"11.346504ms","trace":"4422c78a-c7d0-11e9-b44b-8c8590b37a1d","transport":"http"}
```
^ HTTP server still can recover panic