### PR TITLE
Assign default gRPC status if it does not exist

### DIFF
--- a/utils/errors/errors.go
+++ b/utils/errors/errors.go
@@ -77,9 +77,6 @@ func (c customError) Cause() error {
 }
 
 func (c customError) GRPCStatus() *grpcstatus.Status {
-	if c.status == nil {
-		return grpcstatus.New(codes.Internal, c.Error())
-	}
 	return c.status
 }
 
@@ -178,6 +175,8 @@ func WrapWithSkipAndStatus(err error, msg string, skip int, status *grpcstatus.S
 		// try to get status from existing one from error
 		if s, ok := grpcstatus.FromError(err); ok {
 			status = s
+		} else {
+			status = grpcstatus.New(codes.Internal, msg+err.Error())
 		}
 	}
 


### PR DESCRIPTION
For current implementation of function `WrapWithSkipAndStatus`, if the status is not provided for the first time when the error generated, the status will still remain nil without default value. The default status will be given in the following two situations:
 1. One has generated the error using Orion/utils/errors and then wrap it again. In this case, since the error is originally generated by Orion/utils/errors, the interface `interface { GRPCStatus() *Stauts}` is then implemented. Thus, the default status will be assigned to a status with gRPC code equals to `codes.Internal` in the implemented `GRPCStatus() *Status` function when one wrapping the error again. 
 2. One has generated the error using Orion/utils/errors and this error is passed to another gRPC endpoints. In this case, the reason is the same as above situation. When error is passed to another gRPC endpoint, the implemented `GRPCStatus() *Status` function will be called. Thus, it will then generate a default status with gRPC code equals to `codes.Internal`.

If the default value of the status will be given in the end, then it should be given in the first place when the error is generated rather than when the error is wrapped again or passed to different gRPC endpoints.
 