### PR TITLE
Add Unwrap method to customError

### DIFF
--- a/utils/errors/errors.go
+++ b/utils/errors/errors.go
@@ -107,6 +107,10 @@ func (c *customError) generateStack(skip int) []StackFrame {
 	return stack
 }
 
+func (c customError) Unwrap() error {
+	return c.cause
+}
+
 func packageFuncName(pc uintptr) (string, string) {
 	f := runtime.FuncForPC(pc)
 	if f == nil {


### PR DESCRIPTION
This will make `customError` compatible with the upcoming additions to the `errors` package in Go 1.13: `errors.Is` and `errors.As`. See [here](https://go.googlesource.com/proposal/+/master/design/go2draft-error-inspection.md) for details of the proposal, and see [here](https://godoc.org/golang.org/x/xerrors) for the existing implementation of this proposal, which will be merged into the standard library for Go 1.13.