### PR TITLE
Add stream interceptors

### DIFF
--- a/interceptors/interceptors.go
+++ b/interceptors/interceptors.go
@@ -13,8 +13,8 @@ import (
 	"github.com/carousell/Orion/utils/errors/notifier"
 	"github.com/carousell/Orion/utils/log"
 	"github.com/carousell/Orion/utils/log/loggers"
-	"github.com/grpc-ecosystem/go-grpc-middleware"
-	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	grpc_opentracing "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	newrelic "github.com/newrelic/go-agent"
@@ -59,9 +59,11 @@ func DefaultClientInterceptors(address string) []grpc.UnaryClientInterceptor {
 //DefaultStreamInterceptors are the set of default interceptors that should be applied to all Orion streams
 func DefaultStreamInterceptors() []grpc.StreamServerInterceptor {
 	return []grpc.StreamServerInterceptor{
+		ResponseTimeLoggingStreamInterceptor(),
 		grpc_ctxtags.StreamServerInterceptor(),
 		grpc_opentracing.StreamServerInterceptor(),
 		grpc_prometheus.StreamServerInterceptor,
+		ServerErrorStreamInterceptor(),
 	}
 }
 
@@ -180,5 +182,37 @@ func HystrixClientInterceptor() grpc.UnaryClientInterceptor {
 			defer notifier.NotifyOnPanic(newCtx, method)
 			return invoker(newCtx, method, req, reply, cc, opts...)
 		}, nil)
+	}
+}
+
+// ResponseTimeLoggingStreamInterceptor logs response time for stream RPCs.
+func ResponseTimeLoggingStreamInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
+		defer func(begin time.Time) {
+			log.Info(stream.Context(), "method", info.FullMethod, "error", err, "took", time.Since(begin))
+		}(time.Now())
+		err = handler(srv, stream)
+		return err
+	}
+}
+
+// ServerErrorStreamInterceptor intercepts server errors for stream RPCs and
+// reports them to the error notifier.
+func ServerErrorStreamInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
+		ctx := stream.Context()
+		ctx = notifier.SetTraceId(ctx)
+		t := grpc_ctxtags.Extract(ctx)
+		if t != nil {
+			traceID := notifier.GetTraceId(ctx)
+			t.Set("trace", traceID)
+			ctx = loggers.AddToLogContext(ctx, "trace", traceID)
+		}
+		err = handler(srv, stream)
+		if !modifiers.HasDontLogError(ctx) {
+			notifier.Notify(err, ctx)
+		}
+		return err
+
 	}
 }

--- a/orion/handlers/grpc/grpc.go
+++ b/orion/handlers/grpc/grpc.go
@@ -3,7 +3,6 @@ package grpc
 import (
 	"context"
 	"net"
-	"reflect"
 	"sync"
 	"time"
 
@@ -94,7 +93,6 @@ func (g *grpcHandler) grpcInterceptor() grpc.UnaryServerInterceptor {
 func (g *grpcHandler) grpcStreamInterceptor() grpc.StreamServerInterceptor {
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		interceptor := handlers.GetStreamInterceptors(srv, g.config.CommonConfig)
-		log.Info(context.Background(), "svr", srv, "type", reflect.TypeOf(srv))
 		return interceptor(srv, ss, info, handler)
 	}
 }


### PR DESCRIPTION
This PR adds two stream interceptors to maintain feature parity with regular unary RPC calls. Currently stream RPCs are not logged and errors are not reported, leading to a lack of visibility into the RPC's health. The two interceptors do the following:

- `ResponseTimeLoggingStreamInterceptor` - Log response time for stream RPCs
- `ServerErrorStreamInterceptor` - Report errors from stream RPCs

The unary equivalents are `ResponseTimeLoggingInterceptor` and `ServerErrorInterceptor`.

- [An example branch can be found here](https://github.com/carousell/Orion/compare/stream-interceptors-example#diff-765bb3cc3bf64476dc22ad0b7916f428R16)
- The [handler](https://github.com/carousell/Orion/compare/stream-interceptors-example#diff-ef408c46f9756fa67793750fdfb2ed41R115)
- The [test client](https://github.com/carousell/Orion/compare/stream-interceptors-example#diff-321230f3c3d4538e2aa3f4e35ac0d3e2R58)

Before (when calling our test handler):

```
{"@timestamp":"2019-07-24T06:16:38.447840112Z","caller":"grpc/grpc.go:97","level":"info","svr":{},"type":"*service.svc"}
```

After (happy case):

```
{"@timestamp":"2019-07-24T06:29:59.245017892Z","caller":"interceptors/interceptors.go:192","error":null,"grpcMethod":"/ServiceName_proto.ServiceName/TestStreamInterceptor","level":"info","method":"/ServiceName_proto.ServiceName/TestStreamInterceptor","took":"151.382475ms","trace":"75b85e7b-addc-11e9-9590-0242ac110003"}
```

After (error returned):

```
{"@timestamp":"2019-07-24T06:19:39.067371401Z","caller":"interceptors/interceptors.go:213","err":"this is an error","grpcMethod":"/ServiceName_proto.ServiceName/TestStreamInterceptor","level":"error","stack":[{"file":"/go/src/github.com/carousell/Orion/builder/ServiceName/service/service.go","line":129,"function":"(*svc).TestStreamInterceptor"},{"file":"/go/src/github.com/carousell/Orion/builder/ServiceName/ServiceName_proto/ServiceName.pb.go","line":459,"function":"_ServiceName_TestStreamInterceptor_Handler"},{"file":"/go/src/github.com/carousell/Orion/builder/vendor/github.com/carousell/Orion/orion/handlers/utils.go","line":73,"function":"chainStreamServer.func1.1"},{"file":"/go/src/github.com/carousell/Orion/builder/vendor/github.com/carousell/Orion/interceptors/interceptors.go","line":211,"function":"ServerErrorStreamInterceptor.func1"},{"file":"/go/src/github.com/carousell/Orion/builder/vendor/github.com/carousell/Orion/orion/handlers/utils.go","line":76,"function":"chainStreamServer.func1.1"},{"file":"/go/src/github.com/carousell/Orion/builder/vendor/github.com/grpc-ecosystem/go-grpc-prometheus/server_metrics.go","line":121,"function":"(*ServerMetrics).StreamServerInterceptor.func1"},{"file":"/go/src/github.com/carousell/Orion/builder/vendor/github.com/carousell/Orion/orion/handlers/utils.go","line":76,"function":"chainStreamServer.func1.1"},{"file":"/go/src/github.com/carousell/Orion/builder/vendor/github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing/server_interceptors.go","line":46,"function":"StreamServerInterceptor.func1"},{"file":"/go/src/github.com/carousell/Orion/builder/vendor/github.com/carousell/Orion/orion/handlers/utils.go","line":76,"function":"chainStreamServer.func1.1"},{"file":"/go/src/github.com/carousell/Orion/builder/vendor/github.com/grpc-ecosystem/go-grpc-middleware/tags/interceptors.go","line":34,"function":"StreamServerInterceptor.func1"},{"file":"/go/src/github.com/carousell/Orion/builder/vendor/github.com/carousell/Orion/orion/handlers/utils.go","line":76,"function":"chainStreamServer.func1.1"},{"file":"/go/src/github.com/carousell/Orion/builder/vendor/github.com/carousell/Orion/interceptors/interceptors.go","line":194,"function":"ResponseTimeLoggingStreamInterceptor.func1"},{"file":"/go/src/github.com/carousell/Orion/builder/vendor/github.com/carousell/Orion/orion/handlers/utils.go","line":76,"function":"chainStreamServer.func1.1"},{"file":"/go/src/github.com/carousell/Orion/builder/vendor/github.com/carousell/Orion/orion/handlers/utils.go","line":201,"function":"optionsStreamInterceptor"},{"file":"/go/src/github.com/carousell/Orion/builder/vendor/github.com/carousell/Orion/orion/handlers/utils.go","line":81,"function":"chainStreamServer.func1"},{"file":"/go/src/github.com/carousell/Orion/builder/vendor/github.com/carousell/Orion/orion/handlers/grpc/grpc.go","line":98,"function":"(*grpcHandler).grpcStreamInterceptor.func1"},{"file":"/go/src/github.com/carousell/Orion/builder/vendor/google.golang.org/grpc/server.go","line":1177,"function":"(*Server).processStreamingRPC"},{"file":"/go/src/github.com/carousell/Orion/builder/vendor/google.golang.org/grpc/server.go","line":1249,"function":"(*Server).handleStream"},{"file":"/go/src/github.com/carousell/Orion/builder/vendor/google.golang.org/grpc/server.go","line":685,"function":"(*Server).serveStreams.func1.1"},{"file":"/usr/local/go/src/runtime/asm_amd64.s","line":1337,"function":"goexit"}],"trace":"04107ff2-addb-11e9-9715-0242ac110003"}
{"@timestamp":"2019-07-24T06:19:39.067794422Z","caller":"interceptors/interceptors.go:192","error":"this is an error","grpcMethod":"/ServiceName_proto.ServiceName/TestStreamInterceptor","level":"info","method":"/ServiceName_proto.ServiceName/TestStreamInterceptor","took":"153.693249ms","trace":"04107ff2-addb-11e9-9715-0242ac110003"}
```

Notifier submits error to sentry as expected:

![Screen Shot 2019-07-24 at 2 37 51 PM](https://user-images.githubusercontent.com/409724/61770783-a9a72200-ae20-11e9-89a2-146f52a0cae4.png)
