### PR TITLE
orion error returns grpc status with latest message always

### DIFF
--- a/utils/errors/errors.go
+++ b/utils/errors/errors.go
@@ -77,12 +77,15 @@ func (c customError) Cause() error {
 }
 
 func (c customError) GRPCStatus() *grpcstatus.Status {
-	statusCode := codes.Internal
 	if c.status != nil {
-		statusCode = c.status.Code()
+		// use latest error message and keep other data (e.g. details)
+		newStatus := c.status.Proto()
+		newStatus.Message = c.Error()
+
+		return grpcstatus.FromProto(newStatus)
 	}
 
-	return grpcstatus.New(statusCode, c.Error()) // always return with latest error message
+	return grpcstatus.New(codes.Internal, c.Error())
 }
 
 func (c *customError) generateStack(skip int) []StackFrame {

--- a/utils/errors/errors.go
+++ b/utils/errors/errors.go
@@ -77,10 +77,12 @@ func (c customError) Cause() error {
 }
 
 func (c customError) GRPCStatus() *grpcstatus.Status {
-	if c.status == nil {
-		return grpcstatus.New(codes.Internal, c.Error())
+	statusCode := codes.Internal
+	if c.status != nil {
+		statusCode = c.status.Code()
 	}
-	return c.status
+
+	return grpcstatus.New(statusCode, c.Error()) // always return with latest error message
 }
 
 func (c *customError) generateStack(skip int) []StackFrame {

--- a/utils/errors/errors_test.go
+++ b/utils/errors/errors_test.go
@@ -3,6 +3,8 @@ package errors
 import (
 	"io"
 	"testing"
+
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 func TestWrap(t *testing.T) {
@@ -31,6 +33,11 @@ func TestWrap(t *testing.T) {
 			err := Wrap(tt.err, tt.message)
 			if err.Error() != tt.expected {
 				t.Errorf("(%+v, %+v): expected %+v, got %+v", tt.err, tt.message, tt.expected, err)
+			}
+
+			// ensure GRPC status msg has wrapped content no matter you wrap how many times
+			if grpcstatus.Convert(err).Message() != tt.expected {
+				t.Errorf("GRPC status msg expected %+v, got %+v", tt.expected, grpcstatus.Convert(err).Message())
 			}
 
 		})


### PR DESCRIPTION
the error message got from djgateway calling listing-svc: `cannot create listing on listingsvc :CreateListing :rpc error: code = Internal desc = hystrix: timeout`

you can see the error returned from listing-svc is only `hystrix: timeout` technically but we do wrap every error with custom message in listing-svc. So how it happen without any wrapped message? that's because `Wrap` inherits existing grpc status, so Orion server returns only the message at the beginning as long as you New or Wrap the error as customError.

And now we all use Orion error, so the fix is to enable we always get latest message which is wrapped from customError instead of existing grpc status