### PR TITLE
[CEN-651] Generate global api id in protoc-gen-orion

### DIFF
--- a/protoc-gen-orion/orion.go
+++ b/protoc-gen-orion/orion.go
@@ -9,6 +9,8 @@ package main
 
 import (
 	"bytes"
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -55,6 +57,7 @@ type service struct {
 	Encoders       []*encoder
 	Decoders       []*decoder
 	Handlers       []*handler
+	Methods        []*method // raw rpc method in the protofile
 	Options        []*orionOption
 	Middlewares    []*orionMiddleware
 	Streams        []*stream
@@ -74,6 +77,11 @@ type handler struct {
 	SvcName    string
 	MethodName string
 	Path       string
+}
+type method struct {
+	ApiID       string
+	ServiceName string
+	Name        string
 }
 type stream struct {
 	SvcName      string
@@ -109,6 +117,13 @@ import (
 var _ = orion.ProtoGenVersion1_0
 {{ end }}
 {{ range .Services -}}
+
+// Global ID of each API
+
+/*
+{{ range .Methods }}    "{{.ApiID}}" -> "{{.ServiceName}}.{{.Name}}"
+{{ end }}*/
+
 // Encoders
 {{ range .Encoders }}
 // Register{{.SvcName}}{{.MethodName}}Encoder registers the encoder for {{.MethodName}} method in {{.SvcName}}
@@ -131,7 +146,7 @@ func Register{{.SvcName}}{{.MethodName}}Decoder(svr orion.Server, decoder orion.
 	orion.RegisterDecoder(svr, "{{.SvcName}}", "{{.MethodName}}", decoder)
 }
 {{ end }}
-//Streams
+// Streams
 {{ range .Streams }}
 // {{ . }}
 {{ end }}
@@ -270,24 +285,30 @@ func generate(d *data, file *descriptor.FileDescriptorProto) {
 		s.Streams = make([]*stream, 0)
 		s.ServiceDescVar = serviceDescVar
 		s.ServName = servName
+		s.Methods = make([]*method, 0)
 		d.Services = append(d.Services, s)
 
 		// ** --- START -- Find comments in grpc services
 		path := fmt.Sprintf("6,%d", index) // 6 means service.
-		for i, method := range svc.GetMethod() {
-			commentPath := fmt.Sprintf("%s,2,%d", path, i) // 2 means method in a service.
+		for i, methodItem := range svc.GetMethod() {
+			s.Methods = append(s.Methods, &method{
+				ServiceName: s.ServName,
+				Name:        methodItem.GetName(),
+				ApiID:       getApiID(s.ServName, methodItem.GetName()),
+			})
+			commentPath := fmt.Sprintf("%s,2,%d", path, i) // 2 means methodItem in a service.
 			if loc, ok := comments[commentPath]; ok {
 				text := strings.TrimSuffix(loc.GetLeadingComments(), "\n")
 				for _, line := range strings.Split(text, "\n") {
 					// ** --- END -- Find comments in grpc services
 
 					if option := parseComments(line); option != nil {
-						if method.GetClientStreaming() || method.GetServerStreaming() {
+						if methodItem.GetClientStreaming() || methodItem.GetServerStreaming() {
 							str := new(stream)
 							str.SvcName = svc.GetName()
-							str.MethodName = method.GetName()
-							str.ClientStream = method.GetClientStreaming()
-							str.ServerStream = method.GetServerStreaming()
+							str.MethodName = methodItem.GetName()
+							str.ClientStream = methodItem.GetClientStreaming()
+							str.ServerStream = methodItem.GetServerStreaming()
 							if option.Encoder || option.Decoder {
 								str.Path = option.Path
 								str.Methods = option.Method
@@ -306,7 +327,7 @@ func generate(d *data, file *descriptor.FileDescriptorProto) {
 								// populate encoder
 								enc := new(encoder)
 								enc.SvcName = svc.GetName()
-								enc.MethodName = method.GetName()
+								enc.MethodName = methodItem.GetName()
 								enc.Path = option.Path
 								enc.Methods = methodsString
 								s.Encoders = append(s.Encoders, enc)
@@ -314,7 +335,7 @@ func generate(d *data, file *descriptor.FileDescriptorProto) {
 								// popluate handler
 								han := new(handler)
 								han.SvcName = svc.GetName()
-								han.MethodName = method.GetName()
+								han.MethodName = methodItem.GetName()
 								han.Path = option.Path
 								s.Handlers = append(s.Handlers, han)
 							}
@@ -323,14 +344,14 @@ func generate(d *data, file *descriptor.FileDescriptorProto) {
 								// popluate decoder
 								dec := new(decoder)
 								dec.SvcName = svc.GetName()
-								dec.MethodName = method.GetName()
+								dec.MethodName = methodItem.GetName()
 								s.Decoders = append(s.Decoders, dec)
 							}
 
 							if option.Option {
 								opt := new(orionOption)
 								opt.SvcName = svc.GetName()
-								opt.MethodName = method.GetName()
+								opt.MethodName = methodItem.GetName()
 								opt.OptionType = strings.TrimSpace(option.Value)
 								s.Options = append(s.Options, opt)
 							}
@@ -338,7 +359,7 @@ func generate(d *data, file *descriptor.FileDescriptorProto) {
 							if option.Middleware {
 								mid := new(orionMiddleware)
 								mid.SvcName = svc.GetName()
-								mid.MethodName = method.GetName()
+								mid.MethodName = methodItem.GetName()
 								names := strings.Split(option.Value, ",")
 								for i := range names {
 									names[i] = "\"" + strings.TrimSpace(names[i]) + "\""
@@ -429,4 +450,11 @@ func extractComments(file *descriptor.FileDescriptorProto) map[string]*descripto
 		comments[strings.Join(p, ",")] = loc
 	}
 	return comments
+}
+
+func getApiID(serviceName string, methodName string) (apiID string) {
+	raw := serviceName + "." + methodName
+	hash := md5.Sum([]byte(raw))
+	apiID = hex.EncodeToString(hash[:])[0:8]
+	return
 }

--- a/protoc-gen-orion/orion.go
+++ b/protoc-gen-orion/orion.go
@@ -79,9 +79,9 @@ type handler struct {
 	Path       string
 }
 type method struct {
-	ApiID       string
-	ServiceName string
-	Name        string
+	ApiID   string
+	SvcName string
+	Name    string
 }
 type stream struct {
 	SvcName      string
@@ -121,7 +121,7 @@ var _ = orion.ProtoGenVersion1_0
 // Global ID of each API
 
 /*
-{{ range .Methods }}    "{{.ApiID}}" -> "{{.ServiceName}}.{{.Name}}"
+{{ range .Methods }}    "{{.ApiID}}" -> "{{.SvcName}}.{{.Name}}"
 {{ end }}*/
 
 // Encoders
@@ -292,9 +292,9 @@ func generate(d *data, file *descriptor.FileDescriptorProto) {
 		path := fmt.Sprintf("6,%d", index) // 6 means service.
 		for i, methodItem := range svc.GetMethod() {
 			s.Methods = append(s.Methods, &method{
-				ServiceName: s.ServName,
-				Name:        methodItem.GetName(),
-				ApiID:       getApiID(s.ServName, methodItem.GetName()),
+				SvcName: s.ServName,
+				Name:    methodItem.GetName(),
+				ApiID:   getApiID(s.ServName, methodItem.GetName()),
 			})
 			commentPath := fmt.Sprintf("%s,2,%d", path, i) // 2 means methodItem in a service.
 			if loc, ok := comments[commentPath]; ok {


### PR DESCRIPTION
This change is the first step to maintain a global API id scheme, which can be in future used to aggregate all reliability related information in backend world.

example output in a generated .proto.orion.pb.go file,

> // Global ID of each API
> 
> /*
>     "0cbb7024" -> "ChatService.ReceiveMessage"
>     "0a8abe73" -> "ChatService.InitSendImages"
>     "f0e121c0" -> "ChatService.SendImages"
> */
> 
> // Encoders
> 
> // Handlers
> 
> // Decoders
> 
> // Streams

https://carousell.atlassian.net/wiki/spaces/CT/pages/348127890/Proposal+Global+Error+Code+Scheme