### PR TITLE
Make generated file path case sensitive

### DIFF
--- a/protoc-gen-orion/orion.go
+++ b/protoc-gen-orion/orion.go
@@ -238,7 +238,7 @@ func generateFile(d *data) *plugin.CodeGeneratorResponse_File {
 
 	file := new(plugin.CodeGeneratorResponse_File)
 	file.Content = proto.String(buf.String())
-	file.Name = proto.String(strings.ToLower(d.FileName) + ".orion.pb.go")
+	file.Name = proto.String(d.FileName + ".orion.pb.go")
 	return file
 }
 


### PR DESCRIPTION
The lowercased paths were causing problems when generating protobufs
using case-sensitive filesystems. This hasn't been an issue yet because
the majority of developers are on MacOS, but contractors using Linux are
facing issues where the orion.pb.go files are generated in a different
directory from the corresponding .pb.go files.

For example:

- ./pb/authSvc/AuthSvc.pb.go
- ./pb/authsvc/authsvc.proto.orion.pb.go

On MacOS this is fine, the latter just reuses the path of the first one.
On case sensitive filesytems these two paths are distinct.

Ultimately this results in the following error when attempting to
compile or vet.

```
can't load package: package github.com/carousell/shared-proto/pb/authsvc: case-insensitive import collision: "github.com/carousell/shared-proto/pb/authsvc" and "github.com/carousell/shared-proto/pb/authSvc"
```