### PR TITLE
Use byte encoder for Kafka producer key to allow nil key

### DIFF
--- a/utils/kafka/producer.go
+++ b/utils/kafka/producer.go
@@ -60,13 +60,17 @@ func (p *Producer) Run() {
 }
 
 // Produce sends a message to a particular Kafka topic
-func (p *Producer) Produce(ctx context.Context, topic string, key string, msg []byte) error {
+func (p *Producer) Produce(ctx context.Context, topic string, key []byte, msg []byte) error {
 	if !p.open || p.asyncProducer == nil {
 		return errors.New("producer is closed")
 	}
+	var keyEncoder sarama.Encoder
+	if key != nil {
+		keyEncoder = sarama.ByteEncoder(key)
+	}
 	saramaMsg := &sarama.ProducerMessage{
 		Topic: topic,
-		Key:   sarama.StringEncoder(key),
+		Key:   keyEncoder,
 		Value: sarama.ByteEncoder(msg),
 	}
 	p.asyncProducer.Input() <- saramaMsg

--- a/utils/kafka/producer_test.go
+++ b/utils/kafka/producer_test.go
@@ -27,7 +27,7 @@ func TestProducer(t *testing.T) {
 		producer.Run()
 		defer producer.Close()
 
-		err := producer.Produce(ctx, "test-topic", "test-key", []byte("test-payload"))
+		err := producer.Produce(ctx, "test-topic", []byte("test-key"), []byte("test-payload"))
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -55,7 +55,7 @@ func TestProducer(t *testing.T) {
 		producer.Run()
 		defer producer.Close()
 
-		err := producer.Produce(ctx, "test-topic", "test-key", []byte("test-payload"))
+		err := producer.Produce(ctx, "test-topic", []byte("test-key"), []byte("test-payload"))
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -68,7 +68,7 @@ func TestProducer(t *testing.T) {
 
 	t.Run("uninitialized producer does not accept messages", func(t *testing.T) {
 		producer := Producer{}
-		err := producer.Produce(ctx, "test-topic", "test-key", []byte("test-payload"))
+		err := producer.Produce(ctx, "test-topic", []byte("test-key"), []byte("test-payload"))
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -82,7 +82,7 @@ func TestProducer(t *testing.T) {
 		producer.Run()
 		producer.Close()
 
-		err := producer.Produce(ctx, "test-topic", "test-key", []byte("test-payload"))
+		err := producer.Produce(ctx, "test-topic", []byte("test-key"), []byte("test-payload"))
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}


### PR DESCRIPTION
If you want to send messages to random partitions, you should not specify a `key`. If you pass an empty string `""` for `key`, all messages are sent to the same partition. Instead we need a way of passing a _nil_ value for `key`.