### PR TITLE
Change NewRelic HTTP TX Name Type: default to `fullmethod` and remove `url`

### DIFF
--- a/orion/README.md
+++ b/orion/README.md
@@ -536,7 +536,7 @@ ZipkinInitializer returns a Initializer implementation for Zipkin
 type NewRelicConfig struct {
     APIKey      string
     ServiceName string
-    //HttpTxNameType decides the transaction name logged in NR. Options are "fullmethod" (default), "method" , "url", "route".
+    //HttpTxNameType decides the transaction name logged in NR. Options are "fullmethod" (default), "method" , "route".
     HttpTxNameType    string
     IncludeAttributes []string
     ExcludeAttributes []string

--- a/orion/README.md
+++ b/orion/README.md
@@ -536,7 +536,7 @@ ZipkinInitializer returns a Initializer implementation for Zipkin
 type NewRelicConfig struct {
     APIKey      string
     ServiceName string
-    //HttpTxNameType decides the transaction name logged in NR. Options are "method" (default), "fullmethod", "url", "route". Default is "method"
+    //HttpTxNameType decides the transaction name logged in NR. Options are "fullmethod" (default), "method" , "url", "route".
     HttpTxNameType    string
     IncludeAttributes []string
     ExcludeAttributes []string

--- a/orion/config.go
+++ b/orion/config.go
@@ -73,7 +73,7 @@ type ZipkinConfig struct {
 type NewRelicConfig struct {
 	APIKey            string
 	ServiceName       string
-	//HttpTxNameType decides the transaction name logged in NR. Options are "method" (default), "fullmethod", "url", "route". Default is "method"
+	//HttpTxNameType decides the transaction name logged in NR. Options are "fullmethod" (default), "method" , "url", "route".
 	HttpTxNameType 	  string
 	IncludeAttributes []string
 	ExcludeAttributes []string

--- a/orion/config.go
+++ b/orion/config.go
@@ -73,7 +73,7 @@ type ZipkinConfig struct {
 type NewRelicConfig struct {
 	APIKey            string
 	ServiceName       string
-	//HttpTxNameType decides the transaction name logged in NR. Options are "fullmethod" (default), "method" , "url", "route".
+	//HttpTxNameType decides the transaction name logged in NR. Options are "fullmethod" (default), "method" , "route".
 	HttpTxNameType 	  string
 	IncludeAttributes []string
 	ExcludeAttributes []string

--- a/orion/handlers/http/http.go
+++ b/orion/handlers/http/http.go
@@ -47,14 +47,16 @@ func (h *httpHandler) httpHandler(resp http.ResponseWriter, req *http.Request, s
 }
 
 func (h *httpHandler)  getNRTxName(req *http.Request, service, method, routeURL string) string {
-	nrTxName := method
+	var nrTxName string
 	switch h.config.NRHttpTxNameType {
-	case NRTxNameTypeFullMethod:
-		nrTxName = fmt.Sprintf("%v/%v", service, method)
+	case NRTxNameTypeMethod:
+		nrTxName = method
 	case NRTxNameTypeURL:
 		nrTxName = fmt.Sprintf("%v %v", req.Method, req.URL)
 	case NRTxNameTypeRoute:
 		nrTxName = fmt.Sprintf("%v %v", req.Method, routeURL)
+	default:
+		nrTxName = fmt.Sprintf("%v/%v", service, method)
 	}
 	return nrTxName
 }

--- a/orion/handlers/http/http.go
+++ b/orion/handlers/http/http.go
@@ -51,8 +51,6 @@ func (h *httpHandler)  getNRTxName(req *http.Request, service, method, routeURL 
 	switch h.config.NRHttpTxNameType {
 	case NRTxNameTypeMethod:
 		nrTxName = method
-	case NRTxNameTypeURL:
-		nrTxName = fmt.Sprintf("%v %v", req.Method, req.URL)
 	case NRTxNameTypeRoute:
 		nrTxName = fmt.Sprintf("%v %v", req.Method, routeURL)
 	default:

--- a/orion/handlers/http/types.go
+++ b/orion/handlers/http/types.go
@@ -42,7 +42,6 @@ const (
 const (
 	NRTxNameTypeMethod = "method"
 	NRTxNameTypeFullMethod = "fullmethod"
-	NRTxNameTypeURL = "url"
 	NRTxNameTypeRoute = "route"
 )
 


### PR DESCRIPTION
A follow-up on https://github.com/carousell/Orion/pull/130 and comment https://github.com/carousell/Orion/pull/130#discussion_r402047108

- Changed to default HTTP tx name in NewRelic to `fullmethod`. 
- also removed `url`