### PR TITLE
add tags support

### DIFF
--- a/builder/vendor/github.com/carousell/Orion/utils/errors/notifier/notifier.go
+++ b/builder/vendor/github.com/carousell/Orion/utils/errors/notifier/notifier.go
@@ -21,17 +21,20 @@ import (
 )
 
 var (
-	airbrake      *gobrake.Notifier
-	bugsnagInited bool
-	rollbarInited bool
-	sentryInited  bool
-	serverRoot    string
-	hostname      string
+	airbrake         *gobrake.Notifier
+	bugsnagInited    bool
+	rollbarInited    bool
+	sentryInited     bool
+	sentryTagEnabled bool
+	serverRoot       string
+	hostname         string
 )
 
 const (
 	tracerID = "tracerId"
 )
+
+type Tags map[string]string
 
 // InitAirbrake inits airbrake configuration
 func InitAirbrake(projectID int64, projectKey string) {
@@ -54,6 +57,11 @@ func InitRollbar(token, env string) {
 func InitSentry(dsn string) {
 	raven.SetDSN(dsn)
 	sentryInited = true
+}
+
+func InitSentryWithTagEnabled(dsn string) {
+	InitSentry(dsn)
+	sentryTagEnabled = true
 }
 
 func convToGoBrake(in []errors.StackFrame) []gobrake.StackFrame {
@@ -93,12 +101,18 @@ func convToSentry(in []errors.StackFrame) *raven.Stacktrace {
 	return out
 }
 
-func parseRawData(ctx context.Context, rawData ...interface{}) map[string]interface{} {
+func parseRawData(ctx context.Context, rawData ...interface{}) (map[string]interface{}, map[string]string) {
 	m := make(map[string]interface{})
+	t := make(map[string]string)
 	for pos := range rawData {
 		data := rawData[pos]
 		if _, ok := data.(context.Context); ok {
 			continue
+		}
+		if sentryTags, ok := data.(Tags); ok {
+			for k, v := range sentryTags {
+				t[k] = v
+			}
 		}
 		m[reflect.TypeOf(data).String()+strconv.Itoa(pos)] = data
 	}
@@ -107,7 +121,7 @@ func parseRawData(ctx context.Context, rawData ...interface{}) map[string]interf
 			m[k] = v
 		}
 	}
-	return m
+	return m, t
 }
 
 func Notify(err error, rawData ...interface{}) error {
@@ -182,7 +196,7 @@ func doNotify(err error, skip int, level string, rawData ...interface{}) error {
 		n = gobrake.NewNotice(errWithStack, nil, 1)
 		n.Errors[0].Backtrace = convToGoBrake(errWithStack.StackFrame())
 		if len(list) > 0 {
-			m := parseRawData(ctx, list...)
+			m, _ := parseRawData(ctx, list...)
 			for k, v := range m {
 				n.Context[k] = v
 			}
@@ -196,7 +210,7 @@ func doNotify(err error, skip int, level string, rawData ...interface{}) error {
 	if bugsnagInited {
 		bugsnag.Notify(errWithStack, list...)
 	}
-	parsedData := parseRawData(ctx, list...)
+	parsedData, tagData := parseRawData(ctx, list...)
 	if rollbarInited {
 		fields := []*rollbar.Field{}
 		if len(list) > 0 {
@@ -218,6 +232,9 @@ func doNotify(err error, skip int, level string, rawData ...interface{}) error {
 		}
 		ravenExp := raven.NewException(errWithStack, convToSentry(errWithStack.StackFrame()))
 		packet := raven.NewPacketWithExtra(errWithStack.Error(), parsedData, ravenExp)
+		if sentryTagEnabled {
+			packet.AddTags(tagData)
+		}
 		packet.Level = defLevel
 		raven.Capture(packet, nil)
 	}
@@ -276,13 +293,16 @@ func NotifyOnPanic(rawData ...interface{}) {
 		default:
 			e = errors.NewWithSkip("Panic", 1)
 		}
-		parsedData := parseRawData(ctx, rawData...)
+		parsedData, tagData := parseRawData(ctx, rawData...)
 		if rollbarInited {
 			rollbar.ErrorWithStack(rollbar.CRIT, e, convToRollbar(e.StackFrame()), &rollbar.Field{Name: "panic", Data: r})
 		}
 		if sentryInited {
 			ravenExp := raven.NewException(e, convToSentry(e.StackFrame()))
 			packet := raven.NewPacketWithExtra(e.Error(), parsedData, ravenExp)
+			if sentryTagEnabled {
+				packet.AddTags(tagData)
+			}
 			packet.Level = raven.FATAL
 			raven.Capture(packet, nil)
 		}

--- a/utils/errors/notifier/notifier.go
+++ b/utils/errors/notifier/notifier.go
@@ -22,13 +22,12 @@ import (
 )
 
 var (
-	airbrake         *gobrake.Notifier
-	bugsnagInited    bool
-	rollbarInited    bool
-	sentryInited     bool
-	sentryTagEnabled bool
-	serverRoot       string
-	hostname         string
+	airbrake      *gobrake.Notifier
+	bugsnagInited bool
+	rollbarInited bool
+	sentryInited  bool
+	serverRoot    string
+	hostname      string
 )
 
 const (
@@ -75,11 +74,6 @@ func InitRollbar(token, env string) {
 func InitSentry(dsn string) {
 	raven.SetDSN(dsn)
 	sentryInited = true
-}
-
-func InitSentryWithTagEnabled(dsn string) {
-	InitSentry(dsn)
-	sentryTagEnabled = true
 }
 
 func convToGoBrake(in []errors.StackFrame) []gobrake.StackFrame {
@@ -265,13 +259,13 @@ func doNotify(err error, skip int, level string, rawData ...interface{}) error {
 		}
 		ravenExp := raven.NewException(errWithStack, convToSentry(errWithStack))
 		packet := raven.NewPacketWithExtra(errWithStack.Error(), parsedData, ravenExp)
-		if sentryTagEnabled {
-			for _, tags := range tagData {
-				if sentryTags, ok := tags.(isSentryTags); ok {
-					packet.AddTags(sentryTags.Value())
-				}
+
+		for _, tags := range tagData {
+			if sentryTags, ok := tags.(isSentryTags); ok {
+				packet.AddTags(sentryTags.Value())
 			}
 		}
+
 		packet.Level = defLevel
 		raven.Capture(packet, nil)
 	}
@@ -337,13 +331,13 @@ func NotifyOnPanic(rawData ...interface{}) {
 		if sentryInited {
 			ravenExp := raven.NewException(e, convToSentry(e))
 			packet := raven.NewPacketWithExtra(e.Error(), parsedData, ravenExp)
-			if sentryTagEnabled {
-				for _, tags := range tagData {
-					if sentryTags, ok := tags.(isSentryTags); ok {
-						packet.AddTags(sentryTags.Value())
-					}
+
+			for _, tags := range tagData {
+				if sentryTags, ok := tags.(isSentryTags); ok {
+					packet.AddTags(sentryTags.Value())
 				}
 			}
+
 			packet.Level = raven.FATAL
 			raven.Capture(packet, nil)
 		}

--- a/utils/errors/notifier/notifier.go
+++ b/utils/errors/notifier/notifier.go
@@ -132,8 +132,9 @@ func parseRawData(ctx context.Context, rawData ...interface{}) (extraData map[st
 		}
 		if tags, ok := data.(isTags); ok {
 			tagData = append(tagData, tags.value())
+		} else {
+			extraData[reflect.TypeOf(data).String()+strconv.Itoa(pos)] = data
 		}
-		extraData[reflect.TypeOf(data).String()+strconv.Itoa(pos)] = data
 	}
 	if logFields := loggers.FromContext(ctx); logFields != nil {
 		for k, v := range logFields {


### PR DESCRIPTION
The purpose is to allow adding tags when reporting warning/error.
This greatly reduces efforts when trying to gather context information.
This change will not affect the existing use of sentry.
For service which wants to make use of sentry tags, just a little modification is required.

- notify with tags
```
	notifier.NotifyWithLevel(ErrorPoslaju(), "warning", "extra string data", notifier.SentryTags{
		"order_id":      "this is order id"
		"user_id":       "this is user id",
		"shipping_code": "this is shipping code",
	})
```

All extra data of type `notifier.SentryTags` will be appended to sentry custom tags.

The effect is demonstrated as follows:
![image](https://user-images.githubusercontent.com/9345041/85201718-365da700-b334-11ea-949d-9d3bb82b7661.png)
