### PR TITLE
Fix a lock while handling graceful shutdowns

### DIFF
--- a/orion/core.go
+++ b/orion/core.go
@@ -477,6 +477,7 @@ func (d *DefaultServerImpl) GetConfig() map[string]interface{} {
 func (d *DefaultServerImpl) Stop(timeout time.Duration) error {
 	var wg sync.WaitGroup
 	for _, h := range d.handlers {
+		h.listener.CanClose(true)
 		wg.Add(1)
 		go func(h *handlerInfo, timeout time.Duration) {
 			defer wg.Done()


### PR DESCRIPTION
When handling SIGTERM/SIGINT, the grpc server locks forever. This behavior was introduced in https://github.com/carousell/Orion/pull/132 and https://github.com/carousell/Orion/pull/133.

Goroutine stack trace:

```
goroutine 169 [semacquire, 4 minutes]:
sync.runtime_Semacquire(0xc004a871cc)
	/usr/local/go/src/runtime/sema.go:56 +0x42
sync.(*WaitGroup).Wait(0xc004a871cc)
	/usr/local/go/src/sync/waitgroup.go:130 +0x64
google.golang.org/grpc.(*Server).GracefulStop(0xc004a87080)
	/go/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:1459 +0x1b9
github.com/carousell/Orion/orion/handlers/grpc.(*grpcHandler).Stop(0xc000449a60, 0x6fc23ac00, 0x0, 0x0)
	/go/pkg/mod/github.com/carousell/!orion@v0.0.0-20200630103636-2a24bb6232b2/orion/handlers/grpc/grpc.go:69 +0x108
github.com/carousell/Orion/orion.(*DefaultServerImpl).Stop.func1(0xc002c7d7f0, 0xc000449a80, 0x6fc23ac00)
	/go/pkg/mod/github.com/carousell/!orion@v0.0.0-20200630103636-2a24bb6232b2/orion/core.go:483 +0x6d
created by github.com/carousell/Orion/orion.(*DefaultServerImpl).Stop
	/go/pkg/mod/github.com/carousell/!orion@v0.0.0-20200630103636-2a24bb6232b2/orion/core.go:481 +0xb2
```

`grpc.Server.GracefulStop()` blocks while waiting for the `s.serveWG` waitgroup to be released: https://github.com/grpc/grpc-go/blob/f5b0812e6fe574d90da76b205e9eb51f6ddb1919/server.go#L1456-L1460

Normally `GracefulStop` will close listeners here: https://github.com/grpc/grpc-go/blob/f5b0812e6fe574d90da76b205e9eb51f6ddb1919/server.go#L1445-L1447

However in our custom listener implementation, the listener is prevented from closing unless `.CanClose(true)` has been called on the listener: https://github.com/carousell/Orion/blob/15b116b9496a12b4363434371b6d05be11a49045/utils/listenerutils/listenerutils.go#L34-L39

This results in the listener not being closed when `GracefulStop` is called.

As a result the `grpc.Server.Serve` function blocks here while waiting for new connections from the listener: https://github.com/grpc/grpc-go/blob/f5b0812e6fe574d90da76b205e9eb51f6ddb1919/server.go#L597

This can be seen in the following goroutine stack trace:

```
goroutine 184 [select, 4 minutes]:
github.com/carousell/Orion/utils/listenerutils.(*customListener).Accept(0xc000c0b1a0, 0xc000f36660, 0xc0015e3ea0, 0xc0012e44e8, 0xc0000100c8)
	/go/pkg/mod/github.com/carousell/!orion@v0.0.0-20200630103636-2a24bb6232b2/utils/listenerutils/listenerutils.go:109 +0xde
google.golang.org/grpc.(*Server).Serve(0xc004a87080, 0x7f9ae02e3a28, 0xc000c0b1a0, 0x0, 0x0)
	/go/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:597 +0x22e
github.com/carousell/Orion/orion/handlers/grpc.(*grpcHandler).Run(0xc000449a60, 0x7f9ae02e3a28, 0xc000c0b1a0, 0x7f9ae02e3a28, 0xc000c0b1a0)
	/go/pkg/mod/github.com/carousell/!orion@v0.0.0-20200630103636-2a24bb6232b2/orion/handlers/grpc/grpc.go:62 +0xd9
github.com/carousell/Orion/orion.(*DefaultServerImpl).startHandler.func1(0xc0001948c0, 0xc000449a80)
	/go/pkg/mod/github.com/carousell/!orion@v0.0.0-20200630103636-2a24bb6232b2/orion/core.go:405 +0xbf
created by github.com/carousell/Orion/orion.(*DefaultServerImpl).startHandler
	/go/pkg/mod/github.com/carousell/!orion@v0.0.0-20200630103636-2a24bb6232b2/orion/core.go:403 +0x396
```

At the end of the `grpc.Server.Serve` function the `s.serveWG` waitgroup gets released, which never happens since the function is stuck waiting the `.Accept` call: https://github.com/grpc/grpc-go/blob/f5b0812e6fe574d90da76b205e9eb51f6ddb1919/server.go#L568-L575

---

This PR ensures that listeners are marked as closeable when `.Stop()` is called.