### PR TITLE
Omit healthcheck traces

### DIFF
--- a/interceptors/interceptors.go
+++ b/interceptors/interceptors.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	//FilterMethods is the list of methods that are filtered by default
-	FilterMethods = []string{"Healthcheck"}
+	FilterMethods = []string{"Healthcheck", "HealthCheck"}
 )
 
 func filterFromZipkin(ctx context.Context, fullMethodName string) bool {


### PR DESCRIPTION
Some services define their healthcheck RPC with alternate casing.