### PR TITLE
Add http code to notify in http handler

### DIFF
--- a/builder/vendor/google.golang.org/grpc/go.mod
+++ b/builder/vendor/google.golang.org/grpc/go.mod
@@ -1,5 +1,7 @@
 module google.golang.org/grpc
 
+go 1.14
+
 require (
 	cloud.google.com/go v0.26.0 // indirect
 	github.com/client9/misspell v0.3.4

--- a/builder/vendor/google.golang.org/grpc/go.sum
+++ b/builder/vendor/google.golang.org/grpc/go.sum
@@ -14,6 +14,7 @@ golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3 h1:x/bBzNauLQAlE3fLku/xy92Y
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d h1:g9qWBGx4puODJTMVyoPrpoxPFgVGd+z1DZwjfRu4d0I=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=

--- a/orion/handlers/http/http.go
+++ b/orion/handlers/http/http.go
@@ -72,7 +72,7 @@ func (h *httpHandler) httpHandler(resp http.ResponseWriter, req *http.Request, s
 		if err != nil {
 			httpCode, _ := GrpcErrorToHTTP(err, http.StatusInternalServerError, "Internal Server Error!")
 			tags = notifier.Tags{
-				"http_code": strconv.FormatInt(int64(httpCode), 10),
+				"http_code": strconv.Itoa(httpCode),
 			}
 		}
 


### PR DESCRIPTION
Add "http_code" tag when http handler notifies error

This is to allow filtering of errors by status code (400, 401, 500) on sentry

![image](https://user-images.githubusercontent.com/7568608/91681523-450cd980-eb81-11ea-958c-90912d1f83ce.png)
