### PR TITLE
Add http status in notify

### DIFF
--- a/orion/handlers/http/http.go
+++ b/orion/handlers/http/http.go
@@ -72,7 +72,7 @@ func (h *httpHandler) httpHandler(resp http.ResponseWriter, req *http.Request, s
 		if err != nil {
 			httpCode, _ := GrpcErrorToHTTP(err, http.StatusInternalServerError, "Internal Server Error!")
 			tags = notifier.Tags{
-				"http_code": strconv.FormatInt(int64(httpCode), 10),
+				"http_code": strconv.Itoa(httpCode),
 			}
 		}
 


### PR DESCRIPTION
Add "http_code" tag when http handler notifies error

This is to allow filtering of errors by status code (400, 401, 500) on sentry

![image](https://user-images.githubusercontent.com/7568608/91681523-450cd980-eb81-11ea-958c-90912d1f83ce.png)
