### PR TITLE
modify error tag to fit opentracing convention

### DIFF
--- a/utils/spanutils/spanutils.go
+++ b/utils/spanutils/spanutils.go
@@ -83,7 +83,8 @@ func (span *tracingSpan) SetError(msg string) {
 		return
 	}
 	if msg != "" {
-		span.openSpan.SetTag("error", msg)
+		span.openSpan.SetTag("error", true)
+		span.openSpan.SetTag("error.msg", msg)
 	}
 }
 


### PR DESCRIPTION
According to the opentracing tags spec, the error should be boolean.
https://github.com/opentracing/specification/blob/master/semantic_conventions.md#span-tags-table

The vendor e.g Jaeger will treat the tag as a special render on jaeger-query page.
It will be easier to find error spans by filter the error=true tag also.

![Screen Shot 2020-12-22 at 1 50 15 PM](https://user-images.githubusercontent.com/47513837/102854637-df10ce80-445d-11eb-900c-dded0c1cfb06.png)
<img width="1434" alt="Screen Shot 2020-12-22 at 9 59 40 PM" src="https://user-images.githubusercontent.com/47513837/102896177-ec9b7800-44a0-11eb-9c56-339b82cfe553.png">

 
