### PR TITLE
Create notifier level types and do logging with correct level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+.idea/

--- a/utils/errors/notifier/notifier.go
+++ b/utils/errors/notifier/notifier.go
@@ -171,6 +171,7 @@ func doNotify(err error, skip int, level string, rawData ...interface{}) error {
 	if err == nil {
 		return nil
 	}
+	sev := parseLevel(level)
 
 	// add stack infomation
 	errWithStack, ok := err.(errors.ErrorExt)
@@ -242,16 +243,10 @@ func doNotify(err error, skip int, level string, rawData ...interface{}) error {
 			fields = append(fields, &rollbar.Field{Name: "traceId", Data: traceID})
 		}
 		fields = append(fields, &rollbar.Field{Name: "server", Data: map[string]interface{}{"hostname": getHostname(), "root": getServerRoot()}})
-		rollbar.ErrorWithStack(level, errWithStack, convToRollbar(errWithStack.StackFrame()), fields...)
+		rollbar.ErrorWithStack(sev.String(), errWithStack, convToRollbar(errWithStack.StackFrame()), fields...)
 	}
 
 	if sentryInited {
-		defLevel := raven.ERROR
-		if level == "critical" {
-			defLevel = raven.FATAL
-		} else if level == "warning" {
-			defLevel = raven.WARNING
-		}
 		ravenExp := raven.NewException(errWithStack, convToSentry(errWithStack))
 		packet := raven.NewPacketWithExtra(errWithStack.Error(), parsedData, ravenExp)
 
@@ -259,11 +254,11 @@ func doNotify(err error, skip int, level string, rawData ...interface{}) error {
 			packet.AddTags(tags)
 		}
 
-		packet.Level = defLevel
+		packet.Level = sev.RavenSeverity()
 		raven.Capture(packet, nil)
 	}
 
-	log.GetLogger().Log(ctx, loggers.ErrorLevel, skip+1, "err", errWithStack, "stack", errWithStack.StackFrame())
+	log.GetLogger().Log(ctx, sev.LoggerLevel(), skip+1, "err", errWithStack, "stack", errWithStack.StackFrame())
 	return err
 }
 

--- a/utils/errors/notifier/notifier.go
+++ b/utils/errors/notifier/notifier.go
@@ -254,7 +254,8 @@ func doNotify(err error, skip int, level string, rawData ...interface{}) error {
 			packet.AddTags(tags)
 		}
 
-		packet.Level = sev.RavenSeverity()
+		// type assert directly since it's single use case so we don't consider about wrapping it for now
+		packet.Level = raven.Severity(sev)
 		raven.Capture(packet, nil)
 	}
 

--- a/utils/errors/notifier/types.go
+++ b/utils/errors/notifier/types.go
@@ -5,10 +5,6 @@ package notifier
 // It turns out we expose string type constants for users to use and keep severity type as private for now
 type severity string
 
-func (s severity) String() string {
-	return string(s)
-}
-
 const (
 	ErrorLevel   = "error"
 	DebugLevel   = "debug"
@@ -33,5 +29,6 @@ var (
 		InfoLevel:    infoSeverity,
 		WarningLevel: warningSeverity,
 		FatalLevel:   fatalSeverity,
+		"critical":   fatalSeverity, // backward capability
 	}
 )

--- a/utils/errors/notifier/types.go
+++ b/utils/errors/notifier/types.go
@@ -1,0 +1,37 @@
+package notifier
+
+// We use string as argument to determine the log level from day one,
+// so it's not a big deal to make breaking changes to force everyone to adopt.
+// It turns out we expose string type constants for users to use and keep severity type as private for now
+type severity string
+
+func (s severity) String() string {
+	return string(s)
+}
+
+const (
+	ErrorLevel   = "error"
+	DebugLevel   = "debug"
+	InfoLevel    = "info"
+	WarningLevel = "warning"
+	FatalLevel   = "fatal"
+)
+
+const (
+	errorSeverity   = severity(ErrorLevel)
+	debugSeverity   = severity(DebugLevel)
+	infoSeverity    = severity(InfoLevel)
+	warningSeverity = severity(WarningLevel)
+	fatalSeverity   = severity(FatalLevel)
+)
+
+var (
+	// mainly for mapping string back used
+	levelSeverityMap = map[string]severity{
+		ErrorLevel:   errorSeverity,
+		DebugLevel:   debugSeverity,
+		InfoLevel:    infoSeverity,
+		WarningLevel: warningSeverity,
+		FatalLevel:   fatalSeverity,
+	}
+)

--- a/utils/errors/notifier/utils.go
+++ b/utils/errors/notifier/utils.go
@@ -21,6 +21,8 @@ func (s severity) LoggerLevel() loggers.Level {
 		return loggers.InfoLevel
 	case debugSeverity:
 		return loggers.DebugLevel
+	case errorSeverity:
+		return loggers.ErrorLevel
 	default:
 		return loggers.ErrorLevel
 	}

--- a/utils/errors/notifier/utils.go
+++ b/utils/errors/notifier/utils.go
@@ -1,5 +1,31 @@
 package notifier
 
+import (
+	"github.com/carousell/Orion/utils/log/loggers"
+	"github.com/getsentry/raven-go"
+)
+
+func (s severity) String() string {
+	return string(s)
+}
+
+func (s severity) RavenSeverity() raven.Severity {
+	return raven.Severity(s)
+}
+
+func (s severity) LoggerLevel() loggers.Level {
+	switch s {
+	case warningSeverity:
+		return loggers.WarnLevel
+	case infoSeverity:
+		return loggers.InfoLevel
+	case debugSeverity:
+		return loggers.DebugLevel
+	default:
+		return loggers.ErrorLevel
+	}
+}
+
 func parseLevel(s string) severity {
 	sev, ok := levelSeverityMap[s]
 	if !ok {

--- a/utils/errors/notifier/utils.go
+++ b/utils/errors/notifier/utils.go
@@ -2,15 +2,10 @@ package notifier
 
 import (
 	"github.com/carousell/Orion/utils/log/loggers"
-	"github.com/getsentry/raven-go"
 )
 
 func (s severity) String() string {
 	return string(s)
-}
-
-func (s severity) RavenSeverity() raven.Severity {
-	return raven.Severity(s)
 }
 
 func (s severity) LoggerLevel() loggers.Level {

--- a/utils/errors/notifier/utils.go
+++ b/utils/errors/notifier/utils.go
@@ -1,0 +1,10 @@
+package notifier
+
+func parseLevel(s string) severity {
+	sev, ok := levelSeverityMap[s]
+	if !ok {
+		sev = errorSeverity // by default
+	}
+
+	return sev
+}


### PR DESCRIPTION
notifier allows users to do NotifyWithLevel and the argument is string type, that means the possibility to have human error. It would be great to define our own level type for people who want to use notifier package. 

Also, in this PR, we refactor a little bit the doNotify function to have severity defined at the beginning, so subsequent logic can use it directly and prevent abusing