### PR TITLE
add ForwardMetadata as one of default interceptors

### DIFF
--- a/interceptors/interceptors.go
+++ b/interceptors/interceptors.go
@@ -217,7 +217,7 @@ func ForwardMetadataInterceptor() grpc.UnaryClientInterceptor {
 		md, ok := metadata.FromIncomingContext(ctx)
 		if ok {
 			// means that we have some incoming context values needed to pass through following services
-			// e.g. fulfillgw -> caroorders -> caroship -> caroseveneleven
+			// e.g. api-gateway -> service1 -> service2
 			for key, values := range md {
 				for _, value := range values {
 					ctx = metadata.AppendToOutgoingContext(ctx, key, value)


### PR DESCRIPTION
Metadata is one of the important concepts while communicating multiple microservices, so it's good to have it as default interceptor when calling to other services.