### PR TITLE
reorder defaultclientinterceptors

### DIFF
--- a/interceptors/interceptors.go
+++ b/interceptors/interceptors.go
@@ -53,10 +53,10 @@ func DefaultInterceptors() []grpc.UnaryServerInterceptor {
 //DefaultClientInterceptors are the set of default interceptors that should be applied to all client calls
 func DefaultClientInterceptors(address string) []grpc.UnaryClientInterceptor {
 	return []grpc.UnaryClientInterceptor{
+		HystrixClientInterceptor(),
 		grpc_retry.UnaryClientInterceptor(),
 		GRPCClientInterceptor(),
 		NewRelicClientInterceptor(address),
-		HystrixClientInterceptor(),
 		ForwardMetadataInterceptor(),
 	}
 }


### PR DESCRIPTION
A request that failed could be many reasons including network-level issues, connection re-establishment, etc.. Hystrix as implementing circuit breaker pattern considers how to avoid intermittent network hiccups as well. Also, we don't want to have circuit open because of too many retries that were probably intended.

In other words, we consider Hystrix Command as a whole for a request to other services regardless of whether retry or not.

However, it may be a breaking change to some services that have been using grpc_retry options. We will have to notice those services after we merge this PR. 