### PR TITLE
init incoming context as default for HTTP server

### DIFF
--- a/orion/handlers/http/http.go
+++ b/orion/handlers/http/http.go
@@ -99,6 +99,9 @@ func prepareContext(req *http.Request, info *methodInfo) context.Context {
 	//initialize headers
 	ctx = headers.AddToRequestHeaders(ctx, "", "")
 	ctx = headers.AddToResponseHeaders(ctx, "", "")
+	// initialize incoming context as gRPC server has it naturally
+	// so we can have features where we utilize it for both types of server
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{})
 
 	// fetch and populate whitelisted headers
 	if len(info.svc.requestHeaders) > 0 {


### PR DESCRIPTION
We've onboarded forward metadata via incoming and outgoing context in https://github.com/carousell/Orion/pull/149, but in HTTP server we haven't inited an incoming context inside, which means we can use the metadata in the incoming context that will be transformed to outgoing when we call to other services.

Also, in our current interface of encoders: https://github.com/carousell/Orion/blob/master/orion/handlers/types.go#L40-L44, it doesn't support context assigning back, which will cause new context with incoming context lost. We will have to init an incoming context in preparation stage. (Btw, for gRPC server, the context always has incoming context regardless)