### PR TITLE
add headers only when it presents in request

### DIFF
--- a/orion/handlers/http/http.go
+++ b/orion/handlers/http/http.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/textproto"
 	"strconv"
 	"strings"
 	"time"
@@ -103,7 +104,13 @@ func prepareContext(req *http.Request, info *methodInfo) context.Context {
 	// fetch and populate whitelisted headers
 	if len(info.svc.requestHeaders) > 0 {
 		for _, hdr := range info.svc.requestHeaders {
-			ctx = headers.AddToRequestHeaders(ctx, hdr, req.Header.Get(hdr))
+			if values, found := req.Header[textproto.CanonicalMIMEHeaderKey(hdr)]; found {
+				value := ""
+				if len(values) > 0 {
+					value = values[0]
+				}
+				ctx = headers.AddToRequestHeaders(ctx, hdr, value)
+			}
 		}
 	}
 


### PR DESCRIPTION
Add headers into context when it presents in request only

Before this change, if we have the allow list ["platform", "authentication", "build-no"]
even though you didn't pass anyone of them, it still has empty string in context.

After this change, we will only have headers in context only when it presents in request. Which makes more sense since we do business logic only when requests present in request. 