### PR TITLE
support hystrix error suppressor

### DIFF
--- a/interceptors/interceptors_test.go
+++ b/interceptors/interceptors_test.go
@@ -82,8 +82,27 @@ func TestHystrixClientInterceptorOptionsCanIgnore(t *testing.T) {
 			}
 		}
 
+		invoker := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			return test.err
+		}
+
+		hystrixErr := HystrixClientInterceptor()(
+			context.Background(),
+			"method",
+			nil,
+			nil,
+			nil,
+			invoker,
+			WithHystrixIgnorableErrors(test.ignorableErrors...),
+			WithHystrixIgnorableGRPCCodes(test.ignorableGRPCCodes...),
+		)
+
 		if options.canIgnore(test.err) == test.IsHystrixError {
 			t.Errorf("%s got problems on suppressing errors\n", test.testName)
+		}
+
+		if hystrixErr != test.err {
+			t.Errorf("hystrixInterceptor doesn't return the expected error, got: %v, expect: %v", hystrixErr, test.err)
 		}
 	}
 }

--- a/interceptors/interceptors_test.go
+++ b/interceptors/interceptors_test.go
@@ -1,0 +1,69 @@
+package interceptors
+
+import (
+	"context"
+	"github.com/afex/hystrix-go/hystrix"
+	"github.com/carousell/Orion/utils/errors"
+	"google.golang.org/grpc"
+	"testing"
+)
+
+func TestHystrixClientInterceptor(t *testing.T) {
+	suppressedErr := errors.New("test error")
+	var isHystrixError bool
+	errorSuppressor := func(e error)error{
+		if e == suppressedErr {
+			isHystrixError = false
+			return nil
+		}
+		isHystrixError = true
+		return e
+	}
+
+	tests := []struct{
+		testName string
+		IsHystrixError bool
+		err error
+	}{
+		{
+			testName: "HystrixError",
+			IsHystrixError: true,
+			err: errors.New("hello world"),
+		},
+		{
+			testName: "NonHystrixError",
+			IsHystrixError: false,
+			err: suppressedErr,
+		},
+	}
+
+	// not support concurrent testing yet
+	for _, test:= range tests {
+		// Test WithHystrixErrorSuppressor
+		hystrixCmd := test.testName
+		hystrix.ConfigureCommand(hystrixCmd, hystrix.CommandConfig{
+			ErrorPercentThreshold: 0,
+		})
+		invoker := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			return test.err
+		}
+		err := HystrixClientInterceptor()(
+			context.Background(),
+			"method",
+			nil,
+			nil,
+			nil,
+			invoker,
+			WithHystrixName(hystrixCmd),
+			WithHystrixErrorSuppressor(errorSuppressor),
+		)
+
+		if isHystrixError != test.IsHystrixError {
+			t.Errorf("%s got problems on error suppressor\n", hystrixCmd)
+		}
+		if err != test.err {
+			// we expect the same error as we define but it could be suppressed on hystrix
+			t.Errorf("%s got different errors", hystrixCmd)
+		}
+	}
+}

--- a/interceptors/options.go
+++ b/interceptors/options.go
@@ -9,6 +9,7 @@ type clientOption interface {
 
 type clientOptions struct {
 	hystrixName string
+	hystrixErrorSuppressor func(err error)error
 }
 
 type optionCarrier struct {
@@ -26,6 +27,17 @@ func WithHystrixName(name string) clientOption {
 		processor: func(co *clientOptions) {
 			if name != "" {
 				co.hystrixName = name
+			}
+		},
+	}
+}
+
+// WithHystrixErrorSuppressor applies a function that you can write logics to suppress errors to hystrix interceptor
+func WithHystrixErrorSuppressor(e func(err error) error) clientOption {
+	return &optionCarrier{
+		processor: func(co *clientOptions) {
+			if e != nil {
+				co.hystrixErrorSuppressor = e
 			}
 		},
 	}


### PR DESCRIPTION
While introducing DefaultClientInterceptor in more scenarios, there is a case we need an extension in HystrixInterceptor to suppress some specific errors to not count as hystrix circuit. 

For example, when we use HystrixInterceptor for auth-svc or authentication-related logics, with retry mechanism we may not want to count UnAuthenticate, NotFound as Error in hystrix. Because of high QPS, it could cause hystrix circuit-break easier.