### PR TITLE
Forward headers package

### DIFF
--- a/interceptors/interceptors.go
+++ b/interceptors/interceptors.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"strings"
 
+	"github.com/carousell/Orion/utils/forwardheaders"
+
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
@@ -46,7 +48,7 @@ func DefaultClientInterceptors(address string) []grpc.UnaryClientInterceptor {
 		GRPCClientInterceptor(),
 		NewRelicClientInterceptor(address),
 		HystrixClientInterceptor(),
-		ForwardMetadataInterceptor(),
+		forwardheaders.UnaryClientInterceptor(),
 	}
 }
 
@@ -60,7 +62,7 @@ func DefaultStreamClientInterceptors() []grpc.StreamClientInterceptor {
 	return []grpc.StreamClientInterceptor{
 		grpc_retry.StreamClientInterceptor(),
 		grpc_opentracing.StreamClientInterceptor(),
-		ForwardMetadataStreamClientInterceptor(),
+		forwardheaders.StreamClientInterceptor(),
 	}
 }
 

--- a/interceptors/stream_interceptors.go
+++ b/interceptors/stream_interceptors.go
@@ -1,10 +1,7 @@
 package interceptors
 
 import (
-	"context"
 	"time"
-
-	"google.golang.org/grpc/metadata"
 
 	"github.com/carousell/Orion/orion/modifiers"
 	"github.com/carousell/Orion/utils/errors/notifier"
@@ -43,22 +40,5 @@ func ServerErrorStreamInterceptor() grpc.StreamServerInterceptor {
 		}
 		return err
 
-	}
-}
-
-// ForwardMetadataInterceptor forwards metadata from upstream to downstream
-func ForwardMetadataStreamClientInterceptor() grpc.StreamClientInterceptor {
-	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-		md, ok := metadata.FromIncomingContext(ctx)
-		if ok {
-			// means that we have some incoming context values needed to pass through following services
-			// e.g. api-gateway -> service1 -> service2
-			for key, values := range md {
-				for _, value := range values {
-					ctx = metadata.AppendToOutgoingContext(ctx, key, value)
-				}
-			}
-		}
-		return streamer(ctx, desc, cc, method, opts...)
 	}
 }

--- a/orion/config.go
+++ b/orion/config.go
@@ -51,6 +51,14 @@ type Config struct {
 	Env string
 	// DefaultJSONPB sets jsonpb as the encoder/decoder for application/json request/response bodies
 	DefaultJSONPB bool
+
+	/*
+		Mainly for handler common config
+	*/
+	// ForwardHeaders sets an allowlist to forward headers for both of gRPC and HTTP requests to downstream services
+	ForwardHeaders []string
+	// NoDefaultInterceptors tells the Orion skip including default server interceptors for every protocol
+	NoDefaultInterceptors bool
 }
 
 // HystrixConfig is configuration used by hystrix

--- a/orion/core.go
+++ b/orion/core.go
@@ -241,6 +241,10 @@ func (d *DefaultServerImpl) buildHandlers() []*handlerInfo {
 			EnableProtoURL:   d.config.EnableProtoURL,
 			DefaultJSONPB:    d.config.DefaultJSONPB,
 			NRHttpTxNameType: d.config.NewRelicConfig.HttpTxNameType,
+			CommonConfig: handlers.CommonConfig{
+				NoDefaultInterceptors: d.config.NoDefaultInterceptors,
+				ForwardHeaders:        d.config.ForwardHeaders,
+			},
 		}
 		handler := http.NewHTTPHandler(config)
 		hlrs = append(hlrs, &handlerInfo{
@@ -255,7 +259,12 @@ func (d *DefaultServerImpl) buildHandlers() []*handlerInfo {
 			log.Info(context.Background(), "grpcListener", "could not create listener", "error", err)
 		}
 		log.Info(context.Background(), "gRPCListnerPort", grpcPort)
-		handler := grpcHandler.NewGRPCHandler(grpcHandler.Config{})
+		handler := grpcHandler.NewGRPCHandler(grpcHandler.Config{
+			CommonConfig: handlers.CommonConfig{
+				NoDefaultInterceptors: d.config.NoDefaultInterceptors,
+				ForwardHeaders:        d.config.ForwardHeaders,
+			},
+		})
 		hlrs = append(hlrs, &handlerInfo{
 			handler:  handler,
 			listener: grpcListener,

--- a/orion/handlers/http/http.go
+++ b/orion/handlers/http/http.go
@@ -114,6 +114,16 @@ func prepareContext(req *http.Request, info *methodInfo) context.Context {
 		}
 	}
 
+	// transform http headers to gRPC headers
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		md = metadata.MD{}
+		ctx = metadata.NewIncomingContext(ctx, md)
+	}
+	for k, values := range req.Header {
+		md.Set(k, values...)
+	}
+
 	if values, found := req.Header["Content-Type"]; found {
 		for _, value := range values {
 			headers.AddToRequestHeaders(ctx, "Content-Type", value)

--- a/orion/handlers/types.go
+++ b/orion/handlers/types.go
@@ -83,4 +83,5 @@ type Middlewareable interface {
 //CommonConfig is the config that is common across both http and grpc handlers
 type CommonConfig struct {
 	NoDefaultInterceptors bool
+	ForwardHeaders        []string
 }

--- a/orion/handlers/utils.go
+++ b/orion/handlers/utils.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"reflect"
 
+	"github.com/carousell/Orion/utils/forwardheaders"
+
 	"github.com/carousell/Orion/interceptors"
 	"github.com/carousell/Orion/orion/modifiers"
 	"github.com/carousell/Orion/utils/errors"
@@ -108,7 +110,7 @@ func GetInterceptorsWithMethodMiddlewares(svc interface{}, config CommonConfig, 
 }
 
 func getInterceptors(svc interface{}, config CommonConfig, middlewares []string) []grpc.UnaryServerInterceptor {
-	opts := []grpc.UnaryServerInterceptor{optionsInterceptor}
+	opts := []grpc.UnaryServerInterceptor{optionsInterceptor, forwardheaders.UnaryServerInterceptor(config.ForwardHeaders)}
 
 	// check and add default interceptors
 	if !config.NoDefaultInterceptors {
@@ -129,7 +131,7 @@ func getInterceptors(svc interface{}, config CommonConfig, middlewares []string)
 }
 
 func getStreamInterceptors(svc interface{}, config CommonConfig) []grpc.StreamServerInterceptor {
-	opts := []grpc.StreamServerInterceptor{optionsStreamInterceptor}
+	opts := []grpc.StreamServerInterceptor{optionsStreamInterceptor, forwardheaders.StreamServerInterceptor(config.ForwardHeaders)}
 
 	// check and add default interceptors
 	if !config.NoDefaultInterceptors {

--- a/utils/forwardheaders/forwardheaders.go
+++ b/utils/forwardheaders/forwardheaders.go
@@ -1,0 +1,42 @@
+package forwardheaders
+
+import (
+	"context"
+)
+
+type contextKey string
+
+var (
+	allowlistKey contextKey = "AllowedForwardHeaders"
+)
+
+type hdr struct {
+	allowlist []string
+}
+
+// AllowlistFromContext returns all allowed header keys passed in through context
+func AllowlistFromContext(ctx context.Context) []string {
+	if h := ctx.Value(allowlistKey); h != nil {
+		if headers, ok := h.(*hdr); ok {
+			return headers.allowlist
+		}
+	}
+	return nil
+}
+
+// SetAllowList sets a list of allowed header keys in our package variable in through context
+func SetAllowList(ctx context.Context, keys []string) context.Context {
+	var h *hdr
+	if ctxH := ctx.Value(allowlistKey); ctxH != nil {
+		if convertedH, ok := ctxH.(*hdr); ok {
+			h = convertedH
+		}
+	} else {
+		h = &hdr{make([]string, 0)}
+		ctx = context.WithValue(ctx, allowlistKey, h)
+	}
+	if h != nil && len(keys) > 0 {
+		h.allowlist = keys
+	}
+	return ctx
+}

--- a/utils/forwardheaders/interceptors.go
+++ b/utils/forwardheaders/interceptors.go
@@ -41,7 +41,7 @@ func UnaryClientInterceptor() grpc.UnaryClientInterceptor {
 	}
 }
 
-// ForwardMetadataInterceptor forwards metadata from upstream to downstream
+// StreamClientInterceptor forwards metadata from upstream to downstream
 func StreamClientInterceptor() grpc.StreamClientInterceptor {
 	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 		ctx = forwardHeadersThroughCtx(ctx)

--- a/utils/forwardheaders/interceptors.go
+++ b/utils/forwardheaders/interceptors.go
@@ -1,0 +1,36 @@
+package forwardheaders
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// UnaryClientInterceptor forwards metadata from upstream to downstream
+func UnaryClientInterceptor() grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		md, ok := metadata.FromIncomingContext(ctx)
+		if ok {
+			// means that we have some incoming context values needed to pass through following services
+			// e.g. api-gateway -> service1 -> service2
+			allowlist := AllowlistFromContext(ctx)
+			if allowlist == nil {
+				for key, values := range md {
+					for _, value := range values {
+						ctx = metadata.AppendToOutgoingContext(ctx, key, value)
+					}
+				}
+			} else {
+				for _, key := range allowlist {
+					if values, ok := md[key]; ok {
+						for _, value := range values {
+							ctx = metadata.AppendToOutgoingContext(ctx, key, value)
+						}
+					}
+				}
+			}
+		}
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}

--- a/utils/forwardheaders/interceptors.go
+++ b/utils/forwardheaders/interceptors.go
@@ -7,30 +7,44 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// UnaryClientInterceptor forwards metadata from upstream to downstream
-func UnaryClientInterceptor() grpc.UnaryClientInterceptor {
-	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		md, ok := metadata.FromIncomingContext(ctx)
-		if ok {
-			// means that we have some incoming context values needed to pass through following services
-			// e.g. api-gateway -> service1 -> service2
-			allowlist := AllowlistFromContext(ctx)
-			if allowlist == nil {
-				for key, values := range md {
+func forwardHeadersThroughCtx(ctx context.Context) context.Context {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		// means that we have some incoming context values needed to pass through following services
+		// e.g. api-gateway -> service1 -> service2
+		allowlist := AllowlistFromContext(ctx)
+		if allowlist == nil {
+			for key, values := range md {
+				for _, value := range values {
+					ctx = metadata.AppendToOutgoingContext(ctx, key, value)
+				}
+			}
+		} else {
+			for _, key := range allowlist {
+				if values, ok := md[key]; ok {
 					for _, value := range values {
 						ctx = metadata.AppendToOutgoingContext(ctx, key, value)
 					}
 				}
-			} else {
-				for _, key := range allowlist {
-					if values, ok := md[key]; ok {
-						for _, value := range values {
-							ctx = metadata.AppendToOutgoingContext(ctx, key, value)
-						}
-					}
-				}
 			}
 		}
+	}
+
+	return ctx
+}
+
+// UnaryClientInterceptor forwards metadata from upstream to downstream
+func UnaryClientInterceptor() grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		ctx = forwardHeadersThroughCtx(ctx)
 		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+// ForwardMetadataInterceptor forwards metadata from upstream to downstream
+func StreamClientInterceptor() grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		ctx = forwardHeadersThroughCtx(ctx)
+		return streamer(ctx, desc, cc, method, opts...)
 	}
 }

--- a/utils/forwardheaders/interceptors_test.go
+++ b/utils/forwardheaders/interceptors_test.go
@@ -1,0 +1,51 @@
+package forwardheaders
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc"
+)
+
+func TestUnaryClientInterceptor(t *testing.T) {
+	ctx := context.Background()
+	UnaryClientInterceptor()(ctx, "", new(interface{}), new(interface{}), new(grpc.ClientConn), func(invokerCtx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+		// service function is wrapped during the chain of interceptors
+		// so the context we will use is the one inside here
+		// in order to test it, we do closure here to get the handlerCtx for validations below
+		ctx = invokerCtx
+		return nil
+	})
+
+	allowlist := AllowlistFromContext(ctx)
+	if allowlist != nil {
+		t.Errorf("allowlist is not nil by default")
+	}
+
+	ctx = SetAllowList(ctx, make([]string, 0))
+	UnaryClientInterceptor()(ctx, "", new(interface{}), new(interface{}), new(grpc.ClientConn), func(invokerCtx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+		// service function is wrapped during the chain of interceptors
+		// so the context we will use is the one inside here
+		// in order to test it, we do closure here to get the handlerCtx for validations below
+		ctx = invokerCtx
+		return nil
+	})
+
+	allowlist = AllowlistFromContext(ctx)
+	if allowlist == nil {
+		t.Errorf("allowlist is nil after set")
+	}
+}
+
+func TestAllowlistFromContext(t *testing.T) {
+	ctx := context.Background()
+	if len(AllowlistFromContext(ctx)) != 0 {
+		t.Errorf("allowlist shouldn't have value without set")
+	}
+
+	ctx = SetAllowList(ctx, []string{"platform"})
+
+	if len(AllowlistFromContext(ctx)) != 1 {
+		t.Errorf("the length of allowlist is wrong")
+	}
+}

--- a/utils/forwardheaders/types.go
+++ b/utils/forwardheaders/types.go
@@ -1,0 +1,6 @@
+package forwardheaders
+
+// AllowForwardHeaders is an interface that you need to implement for Orion's services to set the allowlist in the ctx
+type AllowForwardHeaders interface {
+	GetAllowedForwardHeaders() []string
+}

--- a/utils/forwardheaders/types.go
+++ b/utils/forwardheaders/types.go
@@ -1,6 +1,0 @@
-package forwardheaders
-
-// AllowForwardHeaders is an interface that you need to implement for Orion's services to set the allowlist in the ctx
-type AllowForwardHeaders interface {
-	GetAllowedForwardHeaders() []string
-}


### PR DESCRIPTION
The main idea is to have the capability to whitelist outgoing headers and not break our DefaultClientInterceptor.
* Create a forwardheaders package responsible for server and client interceptors, allowlist management through context and some util functions
* Extend orion.config to have forwardheaders as the allowlist
* Extend orion.config to have NoDefaultInterceptors (we have the capability but seems no one set it yet)
* Extend DefaultServerInterceptors to set allowlist for forwardheaders
* Transform HTTP headers into gRPC headers (metadata)