### PR TITLE
Deprecate trace function in notifier package

### DIFF
--- a/interceptors/stream_interceptors.go
+++ b/interceptors/stream_interceptors.go
@@ -9,8 +9,6 @@ import (
 	"github.com/carousell/Orion/orion/modifiers"
 	"github.com/carousell/Orion/utils/errors/notifier"
 	"github.com/carousell/Orion/utils/log"
-	"github.com/carousell/Orion/utils/log/loggers"
-	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	"google.golang.org/grpc"
 )
 
@@ -30,13 +28,6 @@ func ResponseTimeLoggingStreamInterceptor() grpc.StreamServerInterceptor {
 func ServerErrorStreamInterceptor() grpc.StreamServerInterceptor {
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
 		ctx := stream.Context()
-		ctx = notifier.SetTraceId(ctx)
-		t := grpc_ctxtags.Extract(ctx)
-		if t != nil {
-			traceID := notifier.GetTraceId(ctx)
-			t.Set("trace", traceID)
-			ctx = loggers.AddToLogContext(ctx, "trace", traceID)
-		}
 		err = handler(srv, stream)
 		if !modifiers.HasDontLogError(ctx) {
 			notifier.Notify(err, ctx)

--- a/interceptors/unary_interceptors.go
+++ b/interceptors/unary_interceptors.go
@@ -11,8 +11,6 @@ import (
 	"github.com/carousell/Orion/utils/errors"
 	"github.com/carousell/Orion/utils/errors/notifier"
 	"github.com/carousell/Orion/utils/log"
-	"github.com/carousell/Orion/utils/log/loggers"
-	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	grpc_opentracing "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
 	newrelic "github.com/newrelic/go-agent"
 	"google.golang.org/grpc"
@@ -65,15 +63,6 @@ func NewRelicInterceptor() grpc.UnaryServerInterceptor {
 //ServerErrorInterceptor intercepts all server actions and reports them to error notifier
 func ServerErrorInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
-		// set trace id if not set
-		ctx = notifier.SetTraceId(ctx)
-
-		t := grpc_ctxtags.Extract(ctx)
-		if t != nil {
-			traceID := notifier.GetTraceId(ctx)
-			t.Set("trace", traceID)
-			ctx = loggers.AddToLogContext(ctx, "trace", traceID)
-		}
 		// dont log Error for HTTP request, let HTTP Handler manage it
 		if modifiers.IsHTTPRequest(ctx) {
 			return handler(ctx, req)

--- a/orion/handlers/http/ws.go
+++ b/orion/handlers/http/ws.go
@@ -36,7 +36,6 @@ func (h *httpHandler) wsHandler(resp http.ResponseWriter, req *http.Request, ser
 		ctx = loggers.AddToLogContext(ctx, "transport", "ws")
 		req = req.WithContext(ctx)
 
-		notifier.SetTraceId(ctx)
 		log.Info(ctx, "path", req.URL.String(), "msg", "new websocket connection")
 
 		// httpHandler allows handling entire http request


### PR DESCRIPTION
This PR deprecates trace-id functionality from notifier package.

notifier package relies on "trace" set in the span baggage of the parent span based on opentracing spec.

With release of Metadata passing functionality, we want metadata to carry trace information and not the spancontext baggage.
https://github.com/carousell/Orion/pull/149

We recommend forwarding trace information using  `grpc_opentracing.UnaryClientInterceptor`
 from `github.com/grpc-ecosystem/go-grpc-middleware` module.

