### PR TITLE
add a unit test to verify the interceptors execution order is normal

### DIFF
--- a/orion/handlers/utils_test.go
+++ b/orion/handlers/utils_test.go
@@ -21,7 +21,7 @@ func (s *service) GetInterceptors() []grpc.UnaryServerInterceptor {
 	return s.interceptors
 }
 
-func TestGetInterceptors(t *testing.T) {
+func TestGetInterceptorsWithMethodMiddlewares(t *testing.T) {
 	// this test currently verifies the Interceptors is executed at the same sequence that you passed in
 	// gRPC's normal chainUnaryInterceptor is executing interceptor in a reverse order.
 	// but Orion's chainUnaryServer ensure the interceptor execution order is normal (ensure this)
@@ -44,7 +44,7 @@ func TestGetInterceptors(t *testing.T) {
 	}
 	svc := NewMockService(interceptors...)
 
-	serverInterceptor := GetInterceptors(svc, CommonConfig{NoDefaultInterceptors: true})
+	serverInterceptor := GetInterceptorsWithMethodMiddlewares(svc, CommonConfig{NoDefaultInterceptors: true}, []string{})
 	serverInterceptor(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: "test"}, func(ctx context.Context, req interface{}) (interface{}, error) {
 		return nil, nil
 	}) // to trigger the interceptors

--- a/orion/handlers/utils_test.go
+++ b/orion/handlers/utils_test.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"context"
+	"google.golang.org/grpc"
+	"reflect"
+	"testing"
+)
+
+type service struct {
+	interceptors []grpc.UnaryServerInterceptor
+}
+
+func NewMockService(interceptors ...grpc.UnaryServerInterceptor) *service {
+	s := new(service)
+	s.interceptors = interceptors
+	return s
+}
+
+func (s *service) GetInterceptors() []grpc.UnaryServerInterceptor {
+	return s.interceptors
+}
+
+func TestGetInterceptors(t *testing.T) {
+	// this test currently verifies the Interceptors is executed at the same sequence that you passed in
+	// gRPC's normal chainUnaryInterceptor is executing interceptor in a reverse order.
+	// but Orion's chainUnaryServer ensure the interceptor execution order is normal (ensure this)
+
+	sequenceArr := make([]int, 0) // for verifying GetInterceptors execution sequence
+	expectedArr := []int{1, 2, 3}
+	interceptors := []grpc.UnaryServerInterceptor{
+		func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+			sequenceArr = append(sequenceArr, 1)
+			return handler(ctx, req)
+		},
+		func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+			sequenceArr = append(sequenceArr, 2)
+			return handler(ctx, req)
+		},
+		func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+			sequenceArr = append(sequenceArr, 3)
+			return handler(ctx, req)
+		},
+	}
+	svc := NewMockService(interceptors...)
+
+	serverInterceptor := GetInterceptors(svc, CommonConfig{NoDefaultInterceptors: true})
+	serverInterceptor(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: "test"}, func(ctx context.Context, req interface{}) (interface{}, error) {
+		return nil, nil
+	}) // to trigger the interceptors
+
+	if !reflect.DeepEqual(sequenceArr, expectedArr) {
+		t.Errorf("execution sequence is not normal, expected: %v, got: %v\n", expectedArr, sequenceArr)
+	}
+}


### PR DESCRIPTION
Orion's [chainUnaryServer](http://github.com/carousell/Orion/blob/c54848a93c8e634429d4b150879a061e93a9e9e8/orion/handlers/utils.go#L22-L22) executes the interceptors in a normal order while grpc's ChainUnaryInterceptors do it in a reverse order. This added unit test is to ensure the Orion's chainUnaryServer executes interceptors as expected. And, Orion's users can have high confidence at understanding it.