### PR TITLE
Upgrade go.mod to go1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/carousell/Orion
 
-go 1.12
+go 1.17
 
 replace (
 	git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
@@ -73,4 +73,46 @@ require (
 	google.golang.org/genproto v0.0.0-20190128161407-8ac453e89fca // indirect
 	google.golang.org/grpc v1.22.1
 	gopkg.in/airbrake/gobrake.v2 v2.0.9
+)
+
+require (
+	github.com/RichardKnop/redsync v1.2.0 // indirect
+	github.com/armon/go-radix v1.0.0 // indirect
+	github.com/aws/aws-sdk-go v1.15.66 // indirect
+	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect
+	github.com/bradfitz/gomemcache v0.0.0-20180710155616-bc664df96737 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/elastic/go-windows v1.0.0 // indirect
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/gogo/protobuf v1.1.1 // indirect
+	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
+	github.com/gomodule/redigo v2.0.0+incompatible // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/googleapis/gax-go v2.0.0+incompatible // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
+	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 // indirect
+	github.com/kelseyhightower/envconfig v1.3.0 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 // indirect
+	github.com/magiconair/properties v1.8.0 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/mongodb/mongo-go-driver v0.2.0 // indirect
+	github.com/pelletier/go-toml v1.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/cast v1.3.0 // indirect
+	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/streadway/amqp v0.0.0-20180806233856-70e15c650864 // indirect
+	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
+	github.com/xdg/stringprep v1.0.0 // indirect
+	go.elastic.co/fastjson v1.0.0 // indirect
+	go.opencensus.io v0.18.0 // indirect
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58 // indirect
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	google.golang.org/appengine v1.4.0 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
+	howett.net/plist v0.0.0-20181124034731-591f970eefbb // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -38,7 +38,6 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
 github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
-github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bradfitz/gomemcache v0.0.0-20180710155616-bc664df96737 h1:rRISKWyXfVxvoa702s91Zl5oREZTrR3yv+tXrrX7G/g=
 github.com/bradfitz/gomemcache v0.0.0-20180710155616-bc664df96737/go.mod h1:PmM6Mmwb0LSuEubjR8N7PtNe1KxZLtOUHtbeikc5h60=
@@ -93,7 +92,6 @@ github.com/frankban/quicktest v1.13.0/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsouza/fake-gcs-server v1.0.0/go.mod h1:1/HufuJ+eaDf4KTnYdS6HJMGvMRU8d4cYTuu/1QaBbI=
-github.com/garyburd/redigo v1.6.0 h1:0VruCpn7yAIIu7pWVClQC8wxCJEcG3nyzpMSHKi1PQc=
 github.com/garyburd/redigo v1.6.0/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/getsentry/raven-go v0.0.0-20190125112653-238ebd86338d h1:QmQLF7Cm2w24qEFzJcWTHNdYy6mL124T966f6qnMHB0=
 github.com/getsentry/raven-go v0.0.0-20190125112653-238ebd86338d/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=


### PR DESCRIPTION
This PR does nothing but to upgrade go.mod to use go1.17. 

We have [included 1.17 and 1.18 in travis build](https://github.com/carousell/Orion/blob/master/.travis.yml#L5-L6), this should be a safe upgrade.

Tested in  
- [search-suggestion](https://github.com/carousell/search-suggestion/pull/15)

# The impact to Orion development

## Enable new language feature
The upgrade of go version in go.mod enables new language features for development: 
- [number literal since go1.13](https://go.dev/doc/go1.13#language)
- [overlapping interface since go1.14](https://go.dev/doc/go1.14#language)
- [some small enhancement for slice/array since go1.17](https://go.dev/doc/go1.17#language)

And if we go up to go1.18, [generics](https://go.dev/doc/go1.18#generics) will be available.

## Go tools behavior regarding go module 
Go tools take gradual rollout strategy since go module was introduced in go1.11. Almost each major release had some related go tool change.

By upgrading to go1.17, [module graph pruning](https://go.dev/doc/go1.17#go-command) makes the go tool to explicitly listed indirect dependencies in go.mod. And that's why you see a large go.mod in this PR.

However, the added dependencies in go.mod only serves the purpose for resolving dependencies, but not to add more dependencies in existing importing chain.

In addition to this, `go install`, replacing `go get -u`, is now the recommended approach to install go binaries. There are couple places in README.md, makefile must be updated. Will work it in a separate PR.

# The impact to downstream modules

For repos importing Orion, this should not be a breaking change. 

Orion can still be imported by repos using lower version of golang. No compile time error.

_**In general, given a module using lower version golang, only when it starts use code piece in Orion with new language feature, the compile tool report error.**_

Example: assuming we upgrade Orion to go1.18 in go.mod and create a new function using generics. Other repos that is still in go1.17 or before can still import the latest Orion (using go1.18). Everything should be work normally. Only when this repo start using the newly created generic functions, the complier report an error.