### PR TITLE
Add version config to kafka utils

### DIFF
--- a/utils/kafka/config.go
+++ b/utils/kafka/config.go
@@ -67,3 +67,18 @@ func WithErrorHandler(errorHandler func(error)) Option {
 		errorHandler: errorHandler,
 	}
 }
+
+type versionOption struct {
+	version sarama.KafkaVersion
+}
+
+func (opt *versionOption) apply(cfg *config) {
+	cfg.saramaConfig.Version = opt.version
+}
+
+// WithVersion specified the kafka cluster version to connect to
+func WithVersion(version sarama.KafkaVersion) Option {
+	return &versionOption{
+		version: version,
+	}
+}


### PR DESCRIPTION
# Problem

In a recent exercise to onboard trace-id in logging, we upgraded Orion to the latest commit. However, due to complex dependencies between several internal modules, we are forced to upgrade `sarama` to `v1.30.0` (the dependent version by `carousell/messaging`).

With this upgrade, it breaks out publisher to old v0.11.2 kafka cluster. Connecting to kafka client also failed with error `error creating async producer: kafka: client has run out of available brokers to talk to (Is your cluster reachable?)`

# Root Cause

The root cause is since sarama v1.27.1, the [default kafka version in config is changed](https://github.com/Shopify/sarama/commit/a904204126b274b31e532cf4086f6b76a5101794#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L489-R489) from `v0.8.2.0` to `v1.0.0.0`.

If you are connecting to old kafka cluster using v1.27.1+, you have to explicitly specify the `Version` in sarama config https://github.com/Shopify/sarama/blob/v1.27.1/config.go#L425-L431.

# PR Change Summary

However, Orion's [NewProducer()](https://github.com/carousell/Orion/blob/dafc9bfd365df5444d152b0a5c83a9859eb861ff/utils/kafka/producer.go#L20) doesn't expose an option for callers to set version config. 

This PR introduces a new version option allowing callers to specify kafka version when connecting to old version cluster.

# Usage

```golang
import (
    "github.com/Shopify/sarama"
    "github.com/carousell/Orion/utils/kafka"
)

producer, err := kafka.NewProducer(
    []string{"broker1", "broker2", "broker3"}
    kafka.WithVersion(sarama.V0_11_0_2),
    // other options go here...
)
```