### PR TITLE
Read timeouts config for orion server

### DIFF
--- a/orion/config.go
+++ b/orion/config.go
@@ -122,6 +122,8 @@ func BuildDefaultConfig(name string) Config {
 		DefaultJSONPB:              viper.GetBool("orion.DefaultJSONPB"),
 		DisableDefaultInterceptors: viper.GetBool("orion.DisableDefaultInterceptors"),
 		MaxRecvMsgSize:             viper.GetInt("orion.MaxRecvMsgSize"),
+		ReadTimeout:                viper.GetInt("orion.ReadTimeout"),
+		WriteTimeout:               viper.GetInt("orion.WriteTimeout"),
 	}
 }
 

--- a/orion/core.go
+++ b/orion/core.go
@@ -513,6 +513,17 @@ func GetDefaultServer(name string, opts ...DefaultServerOption) Server {
 	return server
 }
 
+// GetDefaultServerWithConfigAndOpts returns a default server object that uses provided configuration
+func GetDefaultServerWithConfigAndOpts(config Config, opts ...DefaultServerOption) Server {
+	server := &DefaultServerImpl{
+		config: config,
+	}
+	for _, opt := range opts {
+		opt.apply(server)
+	}
+	return server
+}
+
 // GetDefaultServerWithConfig returns a default server object that uses provided configuration
 func GetDefaultServerWithConfig(config Config) Server {
 	return &DefaultServerImpl{

--- a/orion/core.go
+++ b/orion/core.go
@@ -513,17 +513,6 @@ func GetDefaultServer(name string, opts ...DefaultServerOption) Server {
 	return server
 }
 
-// GetDefaultServerWithConfigAndOpts returns a default server object that uses provided configuration
-func GetDefaultServerWithConfigAndOpts(config Config, opts ...DefaultServerOption) Server {
-	server := &DefaultServerImpl{
-		config: config,
-	}
-	for _, opt := range opts {
-		opt.apply(server)
-	}
-	return server
-}
-
 // GetDefaultServerWithConfig returns a default server object that uses provided configuration
 func GetDefaultServerWithConfig(config Config) Server {
 	return &DefaultServerImpl{


### PR DESCRIPTION
We needed to have custom timeout for http handler (default is 10s) for longer api calls in BifrostGateway [[PR](https://github.com/carousell/BifrostGateway/pull/237/files)]. 
It also applies server option. There was no method to do that. Hence adding the method.